### PR TITLE
feat: implement authentication and credential storage

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,7 +1,18 @@
+use std::time::Duration;
+
+use artifact_keeper_sdk::{ClientAuthExt, ClientUsersExt};
 use clap::Subcommand;
-use miette::Result;
+use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
+use miette::{IntoDiagnostic, Result};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 
 use crate::cli::GlobalArgs;
+use crate::config::credentials::{
+    StoredCredential, delete_credential, get_credential, store_credential,
+};
+use crate::config::{AppConfig, InstanceConfig};
+use crate::error::AkError;
+use crate::output::{self, OutputFormat};
 
 #[derive(Subcommand)]
 pub enum AuthCommand {
@@ -38,7 +49,7 @@ pub enum AuthCommand {
 pub enum TokenCommand {
     /// Create a new API token
     Create {
-        /// Token description
+        /// Token name/description
         #[arg(long)]
         description: Option<String>,
 
@@ -52,39 +63,374 @@ pub enum TokenCommand {
 }
 
 impl AuthCommand {
-    pub async fn execute(self, _global: &GlobalArgs) -> Result<()> {
+    pub async fn execute(self, global: &GlobalArgs) -> Result<()> {
         match self {
-            Self::Login { url, token } => {
-                let method = if token { "token" } else { "browser" };
-                eprintln!(
-                    "ak auth login: {} auth for {:?} (not yet implemented)",
-                    method, url
-                );
-            }
-            Self::Logout { instance } => {
-                eprintln!("ak auth logout: {:?} (not yet implemented)", instance);
-            }
+            Self::Login { url, token } => login(url.as_deref(), token, global).await,
+            Self::Logout { instance } => logout(instance.as_deref(), global),
             Self::Token { command } => match command {
                 TokenCommand::Create {
                     description,
                     expires_in,
-                } => {
-                    eprintln!(
-                        "ak auth token create: desc={:?} expires={}d (not yet implemented)",
-                        description, expires_in
-                    );
-                }
-                TokenCommand::List => {
-                    eprintln!("ak auth token list (not yet implemented)");
-                }
+                } => token_create(description.as_deref(), expires_in, global).await,
+                TokenCommand::List => token_list(global).await,
             },
-            Self::Whoami => {
-                eprintln!("ak auth whoami (not yet implemented)");
-            }
+            Self::Whoami => whoami(global).await,
             Self::Switch => {
-                eprintln!("ak auth switch (not yet implemented)");
+                eprintln!("Account switching is not yet implemented.");
+                eprintln!("Use `ak auth login --token` with a different token to switch accounts.");
+                Ok(())
             }
         }
-        Ok(())
     }
+}
+
+/// Build an authenticated SDK client for the resolved instance.
+///
+/// If `cred` is `None`, the credential is loaded from the credential store
+/// using `instance_name`.
+fn build_client(
+    instance_name: &str,
+    instance: &InstanceConfig,
+    cred: Option<&StoredCredential>,
+) -> Result<artifact_keeper_sdk::Client> {
+    let owned_cred;
+    let cred = match cred {
+        Some(c) => c,
+        None => {
+            owned_cred = get_credential(instance_name)?;
+            &owned_cred
+        }
+    };
+
+    let auth_value = format!("Bearer {}", cred.access_token);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&auth_value)
+            .map_err(|e| AkError::ConfigError(format!("Invalid token: {e}")))?,
+    );
+
+    let http_client = reqwest::ClientBuilder::new()
+        .default_headers(headers)
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .into_diagnostic()?;
+
+    let base_url = format!("{}/api/{}", instance.url, instance.api_version);
+    Ok(artifact_keeper_sdk::Client::new_with_client(
+        &base_url,
+        http_client,
+    ))
+}
+
+async fn login(url: Option<&str>, use_token: bool, global: &GlobalArgs) -> Result<()> {
+    let config = AppConfig::load()?;
+    let (instance_name, instance) = if let Some(url) = url {
+        let found = config.instances.iter().find(|(_, inst)| inst.url == url);
+        if let Some((name, inst)) = found {
+            (name.as_str().to_string(), inst.clone())
+        } else {
+            return Err(AkError::ConfigError(format!(
+                "No instance configured with URL '{url}'. Run `ak instance add <name> {url}` first."
+            ))
+            .into());
+        }
+    } else {
+        let (name, inst) = config.resolve_instance(global.instance.as_deref())?;
+        (name.to_string(), inst.clone())
+    };
+
+    if global.no_input {
+        let hint = if use_token {
+            "Cannot prompt for token in non-interactive mode. Set AK_TOKEN environment variable instead."
+        } else {
+            "Cannot prompt for credentials in non-interactive mode. Use `--token` flag or set AK_TOKEN."
+        };
+        return Err(AkError::ConfigError(hint.into()).into());
+    }
+
+    if use_token {
+        login_with_token(&instance_name, &instance).await
+    } else {
+        login_with_password(&instance_name, &instance).await
+    }
+}
+
+async fn login_with_token(instance_name: &str, instance: &InstanceConfig) -> Result<()> {
+    eprintln!(
+        "Paste your API token for '{instance_name}' ({}):",
+        instance.url
+    );
+    let token = dialoguer::Password::new()
+        .with_prompt("Token")
+        .interact()
+        .into_diagnostic()?;
+
+    let cred = StoredCredential {
+        access_token: token.trim().to_string(),
+        refresh_token: None,
+    };
+
+    let client = build_client(instance_name, instance, Some(&cred))?;
+    let resp = client
+        .get_current_user()
+        .send()
+        .await
+        .map_err(|e| AkError::NotAuthenticated(format!("Token validation failed: {e}")))?;
+
+    store_credential(instance_name, &cred)?;
+    eprintln!(
+        "Logged in to '{instance_name}' as {} ({})",
+        resp.username, resp.email
+    );
+    Ok(())
+}
+
+async fn login_with_password(instance_name: &str, instance: &InstanceConfig) -> Result<()> {
+    let username: String = dialoguer::Input::new()
+        .with_prompt("Username")
+        .interact_text()
+        .into_diagnostic()?;
+
+    let password = dialoguer::Password::new()
+        .with_prompt("Password")
+        .interact()
+        .into_diagnostic()?;
+
+    let base_url = format!("{}/api/{}", instance.url, instance.api_version);
+    let anon_client = artifact_keeper_sdk::Client::new(&base_url);
+
+    let body = artifact_keeper_sdk::types::LoginRequest {
+        username: username.clone(),
+        password,
+    };
+
+    let resp = anon_client
+        .login()
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| AkError::NotAuthenticated(format!("Login failed: {e}")))?;
+
+    if resp.totp_required == Some(true) {
+        eprintln!("TOTP verification is required but not yet supported in the CLI.");
+        eprintln!("Use `--token` with an API token instead.");
+        return Ok(());
+    }
+
+    let cred = StoredCredential {
+        access_token: resp.access_token.clone(),
+        refresh_token: Some(resp.refresh_token.clone()),
+    };
+    store_credential(instance_name, &cred)?;
+
+    eprintln!("Logged in to '{instance_name}' as {username}");
+    if resp.must_change_password {
+        eprintln!("Warning: You must change your password. Visit the web UI to update it.");
+    }
+
+    Ok(())
+}
+
+fn logout(instance: Option<&str>, global: &GlobalArgs) -> Result<()> {
+    let config = AppConfig::load()?;
+    let (instance_name, _) = config.resolve_instance(instance.or(global.instance.as_deref()))?;
+
+    delete_credential(instance_name)?;
+    eprintln!("Logged out from '{instance_name}'.");
+    Ok(())
+}
+
+async fn whoami(global: &GlobalArgs) -> Result<()> {
+    let config = AppConfig::load()?;
+    let (instance_name, instance) = config.resolve_instance(global.instance.as_deref())?;
+    let client = build_client(instance_name, instance, None)?;
+
+    let user = client
+        .get_current_user()
+        .send()
+        .await
+        .map_err(|e| AkError::NotAuthenticated(format!("Failed to get user info: {e}")))?;
+
+    let info = serde_json::json!({
+        "username": user.username,
+        "email": user.email,
+        "display_name": user.display_name,
+        "admin": user.is_admin,
+        "totp_enabled": user.totp_enabled,
+        "instance": instance_name,
+        "url": instance.url,
+    });
+
+    let table_str = format!(
+        "Username:     {}\n\
+         Email:        {}\n\
+         Display Name: {}\n\
+         Admin:        {}\n\
+         TOTP:         {}\n\
+         Instance:     {} ({})",
+        user.username,
+        user.email,
+        user.display_name.as_deref().unwrap_or("-"),
+        if user.is_admin { "yes" } else { "no" },
+        if user.totp_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        },
+        instance_name,
+        instance.url,
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn token_create(
+    description: Option<&str>,
+    expires_in: u32,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let config = AppConfig::load()?;
+    let (instance_name, instance) = config.resolve_instance(global.instance.as_deref())?;
+    let client = build_client(instance_name, instance, None)?;
+
+    let default_name = format!("ak-cli-{}", chrono::Utc::now().format("%Y%m%d-%H%M%S"));
+    let name = if let Some(desc) = description {
+        desc.to_string()
+    } else if global.no_input {
+        default_name
+    } else {
+        dialoguer::Input::new()
+            .with_prompt("Token name")
+            .default(default_name)
+            .interact_text()
+            .into_diagnostic()?
+    };
+
+    let body = artifact_keeper_sdk::types::CreateApiTokenRequest {
+        name,
+        scopes: vec!["*".to_string()],
+        expires_in_days: Some(i64::from(expires_in)),
+    };
+
+    let resp = client
+        .create_api_token()
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to create token: {e}")))?;
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        println!("{}", resp.token);
+        return Ok(());
+    }
+
+    let info = serde_json::json!({
+        "id": resp.id.to_string(),
+        "name": resp.name,
+        "token": resp.token,
+    });
+
+    let table_str = format!(
+        "Token created successfully!\n\n\
+         ID:    {}\n\
+         Name:  {}\n\
+         Token: {}\n\n\
+         Save this token — it won't be shown again.",
+        resp.id, resp.name, resp.token,
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+fn format_optional_date(date: Option<chrono::DateTime<chrono::Utc>>, fmt: &str) -> String {
+    date.map(|d| d.format(fmt).to_string())
+        .unwrap_or_else(|| "never".into())
+}
+
+async fn token_list(global: &GlobalArgs) -> Result<()> {
+    let config = AppConfig::load()?;
+    let (instance_name, instance) = config.resolve_instance(global.instance.as_deref())?;
+    let client = build_client(instance_name, instance, None)?;
+
+    let user = client
+        .get_current_user()
+        .send()
+        .await
+        .map_err(|e| AkError::NotAuthenticated(format!("Failed to get user info: {e}")))?;
+
+    let tokens = client
+        .list_user_tokens()
+        .id(user.id)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to list tokens: {e}")))?;
+
+    if tokens.items.is_empty() {
+        eprintln!("No API tokens found. Run `ak auth token create` to create one.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for t in &tokens.items {
+            println!("{}", t.id);
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = tokens
+        .items
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "id": t.id.to_string(),
+                "name": t.name,
+                "prefix": t.token_prefix,
+                "scopes": t.scopes.join(", "),
+                "created_at": t.created_at.to_rfc3339(),
+                "expires_at": format_optional_date(t.expires_at, "%+"),
+                "last_used": format_optional_date(t.last_used_at, "%+"),
+            })
+        })
+        .collect();
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL_CONDENSED)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec![
+            "ID",
+            "NAME",
+            "PREFIX",
+            "SCOPES",
+            "CREATED",
+            "EXPIRES",
+            "LAST USED",
+        ]);
+
+    for t in &tokens.items {
+        table.add_row(vec![
+            &t.id.to_string()[..8],
+            &t.name,
+            &t.token_prefix,
+            &t.scopes.join(", "),
+            &t.created_at.format("%Y-%m-%d").to_string(),
+            &format_optional_date(t.expires_at, "%Y-%m-%d"),
+            &format_optional_date(t.last_used_at, "%Y-%m-%d"),
+        ]);
+    }
+
+    let table_str = table.to_string();
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    Ok(())
 }

--- a/src/config/credentials.rs
+++ b/src/config/credentials.rs
@@ -1,1 +1,115 @@
-// Credential storage (keychain + file fallback) — will be expanded in Issue #5
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use miette::{IntoDiagnostic, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::error::AkError;
+
+const KEYRING_SERVICE: &str = "artifact-keeper-cli";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredCredential {
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+}
+
+/// Store a credential for a given instance.
+///
+/// Tries OS keychain first; falls back to a credential file.
+pub fn store_credential(instance: &str, cred: &StoredCredential) -> Result<()> {
+    let json = serde_json::to_string(cred).into_diagnostic()?;
+
+    let keychain_ok = keyring::Entry::new(KEYRING_SERVICE, instance)
+        .and_then(|entry| entry.set_password(&json))
+        .is_ok();
+
+    if keychain_ok {
+        return Ok(());
+    }
+
+    eprintln!("Keychain unavailable, using file fallback");
+    store_to_file(instance, &json)
+}
+
+/// Retrieve a credential for a given instance.
+///
+/// Precedence: `AK_TOKEN` env var -> OS keychain -> credential file.
+pub fn get_credential(instance: &str) -> Result<StoredCredential> {
+    if let Ok(token) = std::env::var("AK_TOKEN") {
+        return Ok(StoredCredential {
+            access_token: token,
+            refresh_token: None,
+        });
+    }
+
+    if let Some(cred) = get_from_keychain(instance) {
+        return Ok(cred);
+    }
+
+    if let Some(json) = load_from_file(instance)? {
+        let cred: StoredCredential = serde_json::from_str(&json).into_diagnostic()?;
+        return Ok(cred);
+    }
+
+    Err(AkError::NotAuthenticated(instance.to_string()).into())
+}
+
+/// Delete credential for a given instance from all stores.
+pub fn delete_credential(instance: &str) -> Result<()> {
+    if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, instance) {
+        let _ = entry.delete_credential();
+    }
+
+    delete_from_file(instance)
+}
+
+fn get_from_keychain(instance: &str) -> Option<StoredCredential> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, instance).ok()?;
+    let json = entry.get_password().ok()?;
+    serde_json::from_str(&json).ok()
+}
+
+// --- File-based fallback ---
+
+fn credentials_path() -> Result<PathBuf> {
+    Ok(super::config_dir()?.join("credentials.json"))
+}
+
+fn load_all_file_creds() -> Result<HashMap<String, String>> {
+    let path = credentials_path()?;
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+    let content = fs::read_to_string(&path).into_diagnostic()?;
+    serde_json::from_str(&content).into_diagnostic()
+}
+
+fn save_all_file_creds(creds: &HashMap<String, String>) -> Result<()> {
+    let path = credentials_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).into_diagnostic()?;
+    }
+    let content = serde_json::to_string_pretty(creds).into_diagnostic()?;
+    fs::write(&path, content).into_diagnostic()
+}
+
+fn store_to_file(instance: &str, json: &str) -> Result<()> {
+    let mut creds = load_all_file_creds()?;
+    creds.insert(instance.to_string(), json.to_string());
+    save_all_file_creds(&creds)
+}
+
+fn load_from_file(instance: &str) -> Result<Option<String>> {
+    let creds = load_all_file_creds()?;
+    Ok(creds.get(instance).cloned())
+}
+
+fn delete_from_file(instance: &str) -> Result<()> {
+    let mut creds = load_all_file_creds()?;
+    if creds.remove(instance).is_some() {
+        save_all_file_creds(&creds)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Implements credential storage with OS keychain (macOS Keychain, Linux secret-service) and JSON file fallback
- Implements all auth commands: `login`, `logout`, `whoami`, `token create`, `token list`
- Supports `AK_TOKEN` env var for CI/CD pipelines (takes priority over stored credentials)
- Non-interactive mode (`--no-input`) fails gracefully with actionable error messages

## Changes

- `src/config/credentials.rs`: Full credential store implementation — `store_credential()`, `get_credential()`, `delete_credential()` with keychain-first, file-fallback strategy
- `src/commands/auth.rs`: All auth commands replaced from stubs to working implementations using the generated SDK

## Auth flows

| Command | Method | SDK Endpoint |
|---------|--------|-------------|
| `ak auth login` | Username/password prompt | `POST /api/v1/auth/login` |
| `ak auth login --token` | Token paste + validation | `GET /api/v1/auth/me` |
| `ak auth logout` | Clear stored credentials | (local only) |
| `ak auth whoami` | Show current user info | `GET /api/v1/auth/me` |
| `ak auth token create` | Generate API token | `POST /api/v1/auth/tokens` |
| `ak auth token list` | List active tokens | `GET /api/v1/users/{id}/tokens` |

## Test plan

- [ ] `ak auth login` — prompts for username/password, stores JWT
- [ ] `ak auth login --token` — prompts for token paste, validates against server
- [ ] `ak auth whoami` — displays user info in table/JSON/YAML
- [ ] `ak auth logout` — clears stored credentials
- [ ] `ak auth token create` — creates token, displays it once
- [ ] `ak auth token list` — lists tokens in table format
- [ ] `AK_TOKEN=xxx ak auth whoami` — uses env var token
- [ ] `ak auth login --no-input` — fails with helpful message

Closes #5