### PR TITLE
feat: auto-detect piped output and add --quiet flag

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -8,14 +8,27 @@ pub enum OutputFormat {
     Quiet,
 }
 
+impl OutputFormat {
+    /// Resolve the effective format, auto-detecting piped output.
+    ///
+    /// When the user hasn't explicitly set a format (i.e. the default "table" is
+    /// in effect) and stdout is not a TTY, switch to JSON for pipe-friendly output.
+    pub fn resolve(&self, explicitly_set: bool) -> &Self {
+        if !explicitly_set && matches!(self, Self::Table) && !console::Term::stdout().is_term() {
+            &Self::Json
+        } else {
+            self
+        }
+    }
+}
+
 /// Render any serializable data in the requested format.
 /// For table output, the caller should provide a pre-formatted table string.
 pub fn render<T: Serialize>(data: &T, format: &OutputFormat, table: Option<String>) -> String {
     match format {
-        OutputFormat::Table => table.unwrap_or_else(|| {
-            // Fallback: pretty JSON if no table provided
-            serde_json::to_string_pretty(data).unwrap_or_default()
-        }),
+        OutputFormat::Table => {
+            table.unwrap_or_else(|| serde_json::to_string_pretty(data).unwrap_or_default())
+        }
         OutputFormat::Json => {
             if console::Term::stdout().is_term() {
                 serde_json::to_string_pretty(data).unwrap_or_default()
@@ -24,11 +37,24 @@ pub fn render<T: Serialize>(data: &T, format: &OutputFormat, table: Option<Strin
             }
         }
         OutputFormat::Yaml => serde_yaml::to_string(data).unwrap_or_default(),
-        OutputFormat::Quiet => String::new(), // Caller handles quiet mode
+        OutputFormat::Quiet => String::new(),
     }
 }
 
-/// Detect if we're in a non-interactive (piped) context.
+/// Detect if stdout is a terminal (interactive context).
 pub fn is_interactive() -> bool {
-    console::Term::stdout().is_term() && console::Term::stderr().is_term()
+    console::Term::stdout().is_term()
+}
+
+/// Create a progress spinner on stderr for long-running operations.
+pub fn spinner(message: &str) -> indicatif::ProgressBar {
+    let pb = indicatif::ProgressBar::new_spinner();
+    pb.set_style(
+        indicatif::ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .unwrap()
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✓"]),
+    );
+    pb.set_message(message.to_string());
+    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+    pb
 }


### PR DESCRIPTION
## Summary

- Auto-detects piped output: defaults to JSON when stdout is not a TTY (unless `--format` is explicitly set)
- Adds `-q`/`--quiet` global flag as shorthand for `--format quiet`
- Adds `spinner()` helper using indicatif for long-running operations
- Adds `OutputFormat::resolve()` method for TTY-aware format selection

## Changes

- `src/cli.rs`: Add `--quiet` flag, auto-detection logic in `execute()`
- `src/output/mod.rs`: `OutputFormat::resolve()`, `spinner()` helper

## Test plan

- [ ] `ak instance list` — table output in terminal
- [ ] `ak instance list | cat` — JSON output when piped
- [ ] `ak instance list --format table | cat` — table output (explicitly set)
- [ ] `ak instance list -q` — quiet mode (IDs only)
- [ ] `AK_FORMAT=yaml ak instance list` — respects env var when piped

Closes #6