### PR TITLE
feat: implement repository browsing and management

### DIFF
--- a/src/commands/client.rs
+++ b/src/commands/client.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+use miette::{IntoDiagnostic, Result};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+
+use crate::cli::GlobalArgs;
+use crate::config::credentials::{StoredCredential, get_credential};
+use crate::config::{AppConfig, InstanceConfig};
+use crate::error::AkError;
+
+/// Build an authenticated SDK client for the resolved instance.
+///
+/// If `cred` is `None`, loads from the credential store (keychain/file/env).
+pub fn build_client(
+    instance_name: &str,
+    instance: &InstanceConfig,
+    cred: Option<&StoredCredential>,
+) -> Result<artifact_keeper_sdk::Client> {
+    let owned_cred;
+    let cred = match cred {
+        Some(c) => c,
+        None => {
+            owned_cred = get_credential(instance_name)?;
+            &owned_cred
+        }
+    };
+
+    let auth_value = format!("Bearer {}", cred.access_token);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&auth_value)
+            .map_err(|e| AkError::ConfigError(format!("Invalid token: {e}")))?,
+    );
+
+    let http_client = reqwest::ClientBuilder::new()
+        .default_headers(headers)
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .into_diagnostic()?;
+
+    let base_url = format!("{}/api/{}", instance.url, instance.api_version);
+    Ok(artifact_keeper_sdk::Client::new_with_client(
+        &base_url,
+        http_client,
+    ))
+}
+
+/// Resolve instance and build an authenticated client from GlobalArgs.
+///
+/// Returns the instance name, config, and SDK client for commands that
+/// need all three (e.g. auth commands that display the instance name).
+pub fn authenticated_client(
+    global: &GlobalArgs,
+) -> Result<(String, InstanceConfig, artifact_keeper_sdk::Client)> {
+    let config = AppConfig::load()?;
+    let (name, instance) = config.resolve_instance(global.instance.as_deref())?;
+    let client = build_client(name, instance, None)?;
+    Ok((name.to_string(), instance.clone(), client))
+}
+
+/// Resolve instance and return only the authenticated SDK client.
+///
+/// Convenience wrapper for commands that don't need the instance metadata.
+pub fn client_for(global: &GlobalArgs) -> Result<artifact_keeper_sdk::Client> {
+    let (_, _, client) = authenticated_client(global)?;
+    Ok(client)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin;
 pub mod artifact;
 pub mod auth;
+pub mod client;
 pub mod completion;
 pub mod config;
 pub mod doctor;

--- a/src/commands/repo.rs
+++ b/src/commands/repo.rs
@@ -1,7 +1,12 @@
+use artifact_keeper_sdk::ClientRepositoriesExt;
 use clap::Subcommand;
-use miette::Result;
+use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
+use miette::{IntoDiagnostic, Result};
 
+use super::client::client_for;
 use crate::cli::GlobalArgs;
+use crate::error::AkError;
+use crate::output::{self, OutputFormat};
 
 #[derive(Subcommand)]
 pub enum RepoCommand {
@@ -18,6 +23,14 @@ pub enum RepoCommand {
         /// Search by name
         #[arg(long)]
         search: Option<String>,
+
+        /// Page number
+        #[arg(long, default_value = "1")]
+        page: i32,
+
+        /// Results per page
+        #[arg(long, default_value = "50")]
+        per_page: i32,
     },
 
     /// Show repository details
@@ -62,39 +75,318 @@ pub enum RepoCommand {
 }
 
 impl RepoCommand {
-    pub async fn execute(self, _global: &GlobalArgs) -> Result<()> {
+    pub async fn execute(self, global: &GlobalArgs) -> Result<()> {
         match self {
             Self::List {
                 format,
                 repo_type,
                 search,
+                page,
+                per_page,
             } => {
-                eprintln!(
-                    "ak repo list: format={:?} type={:?} search={:?} (not yet implemented)",
-                    format, repo_type, search
-                );
+                list_repos(
+                    format.as_deref(),
+                    repo_type.as_deref(),
+                    search.as_deref(),
+                    page,
+                    per_page,
+                    global,
+                )
+                .await
             }
-            Self::Show { key } => {
-                eprintln!("ak repo show: {} (not yet implemented)", key);
-            }
+            Self::Show { key } => show_repo(&key, global).await,
             Self::Create {
                 key,
                 format,
                 repo_type,
                 description,
-            } => {
-                eprintln!(
-                    "ak repo create: {} format={} type={} desc={:?} (not yet implemented)",
-                    key, format, repo_type, description
-                );
-            }
-            Self::Delete { key, yes } => {
-                eprintln!("ak repo delete: {} yes={} (not yet implemented)", key, yes);
-            }
-            Self::Browse { key } => {
-                eprintln!("ak repo browse: {} (not yet implemented)", key);
-            }
+            } => create_repo(&key, &format, &repo_type, description.as_deref(), global).await,
+            Self::Delete { key, yes } => delete_repo(&key, yes, global).await,
+            Self::Browse { key } => browse_repo(&key, global).await,
         }
-        Ok(())
     }
+}
+
+fn format_bytes(bytes: i64) -> String {
+    const KB: i64 = 1024;
+    const MB: i64 = KB * 1024;
+    const GB: i64 = MB * 1024;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+async fn list_repos(
+    format_filter: Option<&str>,
+    type_filter: Option<&str>,
+    search: Option<&str>,
+    page: i32,
+    per_page: i32,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for(global)?;
+
+    let spinner = crate::output::spinner("Fetching repositories...");
+
+    let mut req = client.list_repositories().page(page).per_page(per_page);
+
+    if let Some(fmt) = format_filter {
+        req = req.format(fmt);
+    }
+    if let Some(t) = type_filter {
+        req = req.type_(t);
+    }
+    if let Some(q) = search {
+        req = req.q(q);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to list repositories: {e}")))?;
+
+    spinner.finish_and_clear();
+
+    if resp.items.is_empty() {
+        eprintln!("No repositories found.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for repo in &resp.items {
+            println!("{}", repo.key);
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp
+        .items
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "key": r.key,
+                "name": r.name,
+                "format": r.format,
+                "type": r.repo_type,
+                "public": r.is_public,
+                "storage_used": format_bytes(r.storage_used_bytes),
+                "storage_used_bytes": r.storage_used_bytes,
+                "description": r.description,
+            })
+        })
+        .collect();
+
+    let table_str = {
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL_CONDENSED)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(vec!["KEY", "NAME", "FORMAT", "TYPE", "PUBLIC", "STORAGE"]);
+
+        for r in &resp.items {
+            let public = if r.is_public { "yes" } else { "no" };
+            let storage = format_bytes(r.storage_used_bytes);
+            table.add_row(vec![
+                r.key.as_str(),
+                r.name.as_str(),
+                r.format.as_str(),
+                r.repo_type.as_str(),
+                public,
+                &storage,
+            ]);
+        }
+
+        table.to_string()
+    };
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    // Show pagination info on stderr
+    if resp.pagination.total_pages > 1 {
+        eprintln!(
+            "Page {} of {} ({} total repositories)",
+            resp.pagination.page, resp.pagination.total_pages, resp.pagination.total
+        );
+    }
+
+    Ok(())
+}
+
+async fn show_repo(key: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    let repo = client
+        .get_repository()
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to get repository: {e}")))?;
+
+    let info = serde_json::json!({
+        "key": repo.key,
+        "name": repo.name,
+        "format": repo.format,
+        "type": repo.repo_type,
+        "public": repo.is_public,
+        "description": repo.description,
+        "storage_used": format_bytes(repo.storage_used_bytes),
+        "storage_used_bytes": repo.storage_used_bytes,
+        "quota_bytes": repo.quota_bytes,
+        "created_at": repo.created_at.to_rfc3339(),
+        "updated_at": repo.updated_at.to_rfc3339(),
+    });
+
+    let table_str = format!(
+        "Key:          {}\n\
+         Name:         {}\n\
+         Format:       {}\n\
+         Type:         {}\n\
+         Public:       {}\n\
+         Description:  {}\n\
+         Storage Used: {}\n\
+         Quota:        {}\n\
+         Created:      {}\n\
+         Updated:      {}",
+        repo.key,
+        repo.name,
+        repo.format,
+        repo.repo_type,
+        if repo.is_public { "yes" } else { "no" },
+        repo.description.as_deref().unwrap_or("-"),
+        format_bytes(repo.storage_used_bytes),
+        repo.quota_bytes
+            .map(format_bytes)
+            .unwrap_or_else(|| "unlimited".into()),
+        repo.created_at.format("%Y-%m-%d %H:%M:%S UTC"),
+        repo.updated_at.format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn create_repo(
+    key: &str,
+    format: &str,
+    repo_type: &str,
+    description: Option<&str>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for(global)?;
+
+    let body = artifact_keeper_sdk::types::CreateRepositoryRequest {
+        key: key.to_string(),
+        name: key.to_string(),
+        format: format.to_string(),
+        repo_type: repo_type.to_string(),
+        description: description.map(|d| d.to_string()),
+        is_public: None,
+        quota_bytes: None,
+        upstream_url: None,
+    };
+
+    let resp = client
+        .create_repository()
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to create repository: {e}")))?;
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        println!("{}", resp.key);
+        return Ok(());
+    }
+
+    eprintln!(
+        "Created repository '{}' (format: {}, type: {})",
+        resp.key, resp.format, resp.repo_type
+    );
+
+    Ok(())
+}
+
+async fn delete_repo(key: &str, skip_confirm: bool, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    let needs_confirmation = !skip_confirm && !global.no_input;
+    if needs_confirmation {
+        let confirmed = dialoguer::Confirm::new()
+            .with_prompt(format!("Delete repository '{key}'? This cannot be undone"))
+            .default(false)
+            .interact()
+            .into_diagnostic()?;
+
+        if !confirmed {
+            eprintln!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    client
+        .delete_repository()
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to delete repository: {e}")))?;
+
+    eprintln!("Deleted repository '{key}'.");
+    Ok(())
+}
+
+async fn browse_repo(key: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    let spinner = crate::output::spinner("Loading artifacts...");
+
+    let resp = client
+        .list_artifacts()
+        .key(key)
+        .per_page(100)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to list artifacts: {e}")))?;
+
+    spinner.finish_and_clear();
+
+    if resp.items.is_empty() {
+        eprintln!("No artifacts in repository '{key}'.");
+        return Ok(());
+    }
+
+    if global.no_input {
+        // Non-interactive: just list artifacts
+        for a in &resp.items {
+            println!("{}", a.path);
+        }
+        return Ok(());
+    }
+
+    // Interactive fuzzy select
+    let items: Vec<String> = resp.items.iter().map(|a| a.path.clone()).collect();
+
+    let selection = dialoguer::FuzzySelect::new()
+        .with_prompt(format!("Browse artifacts in '{key}'"))
+        .items(&items)
+        .interact_opt()
+        .into_diagnostic()?;
+
+    if let Some(idx) = selection {
+        let artifact = &resp.items[idx];
+        println!(
+            "{}",
+            serde_json::to_string_pretty(artifact).unwrap_or_default()
+        );
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Implements all 5 repo subcommands: `list`, `show`, `create`, `delete`, `browse`
- Extracts shared authenticated client builder into `commands/client.rs` for reuse across all command modules
- Refactors `auth.rs` to use the shared client builder, eliminating duplicated HTTP client code

## Changes

| File | Change |
|------|--------|
| `src/commands/client.rs` | **New** — shared `build_client`, `authenticated_client`, `client_for` |
| `src/commands/repo.rs` | Full implementation replacing stubs |
| `src/commands/auth.rs` | Refactored to use shared client builder |
| `src/commands/mod.rs` | Added `client` module |

## Commands

| Command | SDK Endpoint | Features |
|---------|-------------|----------|
| `ak repo list` | `GET /repositories` | Pagination, `--format`/`--type`/`--search` filters, spinner |
| `ak repo show <key>` | `GET /repositories/{key}` | Storage stats, quota, timestamps |
| `ak repo create <key>` | `POST /repositories` | Format, type, description |
| `ak repo delete <key>` | `DELETE /repositories/{key}` | Interactive confirm, `--yes` skip |
| `ak repo browse <key>` | `GET /repositories/{key}/artifacts` | Fuzzy-select artifact browser |

## Test plan

- [ ] `ak repo list` — paginated table of repositories
- [ ] `ak repo list --format npm --type local` — filtered listing
- [ ] `ak repo list --format json` — JSON output
- [ ] `ak repo show my-repo` — detailed repository info
- [ ] `ak repo create test-repo --format generic --description "Test"` — creates repo
- [ ] `ak repo delete test-repo` — prompts for confirmation
- [ ] `ak repo delete test-repo --yes` — skips confirmation
- [ ] `ak repo browse my-repo` — interactive artifact browser

Closes #7