### PR TITLE
feat: cross-instance artifact copy and bulk migration

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,29 @@ pub enum Command {
     /// Diagnose configuration and connectivity issues
     Doctor,
 
+    /// Migrate artifacts between instances in bulk
+    Migrate {
+        /// Source instance name
+        #[arg(long)]
+        from_instance: String,
+
+        /// Source repository key
+        #[arg(long)]
+        from_repo: String,
+
+        /// Destination instance (defaults to current instance)
+        #[arg(long)]
+        to_instance: Option<String>,
+
+        /// Destination repository key
+        #[arg(long)]
+        to_repo: String,
+
+        /// Preview what would be migrated without transferring
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Administrative operations (backup, cleanup, users, plugins)
     Admin {
         #[command(subcommand)]
@@ -149,6 +172,23 @@ impl Cli {
             Command::Setup { command } => command.execute(&global).await,
             Command::Scan { command } => command.execute(&global).await,
             Command::Doctor => commands::doctor::execute(&global).await,
+            Command::Migrate {
+                from_instance,
+                from_repo,
+                to_instance,
+                to_repo,
+                dry_run,
+            } => {
+                commands::migrate::execute(
+                    &from_instance,
+                    &from_repo,
+                    to_instance.as_deref(),
+                    &to_repo,
+                    dry_run,
+                    &global,
+                )
+                .await
+            }
             Command::Admin { command } => command.execute(&global).await,
             Command::Config { command } => command.execute(&global).await,
             Command::Tui => commands::tui::execute(&global).await,

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -1,0 +1,218 @@
+use artifact_keeper_sdk::ClientRepositoriesExt;
+use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
+use futures::StreamExt;
+use miette::{IntoDiagnostic, Result};
+
+use super::client::build_client;
+use crate::cli::GlobalArgs;
+use crate::config::AppConfig;
+use crate::error::AkError;
+use crate::output::{self, OutputFormat, format_bytes};
+
+/// Migrate artifacts between instances or repositories in bulk.
+pub async fn execute(
+    from_instance: &str,
+    from_repo: &str,
+    to_instance: Option<&str>,
+    to_repo: &str,
+    dry_run: bool,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let config = AppConfig::load()?;
+
+    let (src_name, src_instance) = config.resolve_instance(Some(from_instance))?;
+    let (dst_name, dst_instance) =
+        config.resolve_instance(to_instance.or(global.instance.as_deref()))?;
+
+    let src_client = build_client(src_name, src_instance, None)?;
+    let dst_client = build_client(dst_name, dst_instance, None)?;
+
+    let spinner = output::spinner(&format!("Listing artifacts in {src_name}:{from_repo}..."));
+
+    let mut all_artifacts = Vec::new();
+    let mut page = 1;
+    let page_size = 100;
+    loop {
+        let resp = src_client
+            .list_artifacts()
+            .key(from_repo)
+            .page(page)
+            .per_page(page_size)
+            .send()
+            .await
+            .map_err(|e| AkError::ServerError(format!("Failed to list source artifacts: {e}")))?;
+
+        let is_last_page = resp.items.len() < page_size as usize;
+        all_artifacts.extend(resp.items.clone());
+        if is_last_page {
+            break;
+        }
+        page += 1;
+    }
+
+    spinner.finish_and_clear();
+
+    if all_artifacts.is_empty() {
+        eprintln!("No artifacts found in {src_name}:{from_repo}.");
+        return Ok(());
+    }
+
+    let total_size: i64 = all_artifacts.iter().map(|a| a.size_bytes).sum();
+
+    eprintln!(
+        "Found {} artifacts ({}) in {src_name}:{from_repo}",
+        all_artifacts.len(),
+        format_bytes(total_size),
+    );
+
+    if dry_run {
+        if matches!(global.format, OutputFormat::Quiet) {
+            for a in &all_artifacts {
+                println!("{}", a.path);
+            }
+            return Ok(());
+        }
+
+        let entries: Vec<_> = all_artifacts
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "path": a.path,
+                    "version": a.version,
+                    "size": format_bytes(a.size_bytes),
+                    "size_bytes": a.size_bytes,
+                })
+            })
+            .collect();
+
+        let table_str = {
+            let mut table = Table::new();
+            table
+                .load_preset(UTF8_FULL_CONDENSED)
+                .set_content_arrangement(ContentArrangement::Dynamic)
+                .set_header(vec!["PATH", "VERSION", "SIZE"]);
+
+            for a in &all_artifacts {
+                let version = a.version.as_deref().unwrap_or("-");
+                let size = format_bytes(a.size_bytes);
+                table.add_row(vec![a.path.as_str(), version, &size]);
+            }
+
+            table.to_string()
+        };
+
+        println!(
+            "{}",
+            output::render(&entries, &global.format, Some(table_str))
+        );
+
+        eprintln!(
+            "\nDry run: would migrate {} artifacts ({}) from {src_name}:{from_repo} to {dst_name}:{to_repo}.",
+            all_artifacts.len(),
+            format_bytes(total_size),
+        );
+
+        return Ok(());
+    }
+
+    if !global.no_input {
+        let confirmed = dialoguer::Confirm::new()
+            .with_prompt(format!(
+                "Migrate {} artifacts from {src_name}:{from_repo} to {dst_name}:{to_repo}?",
+                all_artifacts.len()
+            ))
+            .default(false)
+            .interact()
+            .into_diagnostic()?;
+
+        if !confirmed {
+            eprintln!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let pb = indicatif::ProgressBar::new(all_artifacts.len() as u64);
+    pb.set_style(
+        indicatif::ProgressStyle::with_template("{msg} [{bar:40.cyan/blue}] {pos}/{len} ({eta})")
+            .unwrap()
+            .progress_chars("█▉▊▋▌▍▎▏ "),
+    );
+    pb.set_message("Migrating");
+
+    let mut success_count = 0u64;
+    let mut fail_count = 0u64;
+    let mut bytes_transferred: i64 = 0;
+
+    for artifact in &all_artifacts {
+        let result =
+            migrate_single_artifact(&src_client, from_repo, &artifact.path, &dst_client, to_repo)
+                .await;
+
+        match result {
+            Ok(size) => {
+                success_count += 1;
+                bytes_transferred += size;
+            }
+            Err(e) => {
+                fail_count += 1;
+                pb.suspend(|| {
+                    eprintln!("  Failed: {} — {e}", artifact.path);
+                });
+            }
+        }
+
+        pb.inc(1);
+    }
+
+    pb.finish_and_clear();
+
+    eprintln!(
+        "Migration complete: {} succeeded, {} failed ({})",
+        success_count,
+        fail_count,
+        format_bytes(bytes_transferred),
+    );
+
+    if fail_count > 0 {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+async fn migrate_single_artifact(
+    src_client: &artifact_keeper_sdk::Client,
+    src_repo: &str,
+    artifact_path: &str,
+    dst_client: &artifact_keeper_sdk::Client,
+    dst_repo: &str,
+) -> std::result::Result<i64, String> {
+    let resp = src_client
+        .download_artifact()
+        .key(src_repo)
+        .path(artifact_path)
+        .send()
+        .await
+        .map_err(|e| format!("download: {e}"))?;
+
+    let mut bytes = Vec::new();
+    let mut stream = resp.into_inner();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("stream: {e}"))?;
+        bytes.extend_from_slice(&chunk);
+    }
+
+    let size = bytes.len() as i64;
+    let body = reqwest::Body::from(bytes);
+
+    dst_client
+        .upload_artifact()
+        .key(dst_repo)
+        .path(artifact_path)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("upload: {e}"))?;
+
+    Ok(size)
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod completion;
 pub mod config;
 pub mod doctor;
 pub mod instance;
+pub mod migrate;
 pub mod repo;
 pub mod scan;
 pub mod setup;


### PR DESCRIPTION
## Summary

- Enhance `ak artifact copy` with `--from-instance` and `--to-instance` flags for cross-instance transfers via download+upload streaming
- Same-instance copy continues to use efficient server-side promote API
- Add `ak migrate` top-level command for bulk artifact migration between instances with progress bar, per-artifact error handling, dry-run mode, and confirmation prompts
- Paginated source listing to handle large repositories (100 artifacts per page)

## Test plan

- [ ] Verify `ak artifact copy repo/path dest-repo` still works (same-instance, server-side promote)
- [ ] Verify `ak artifact copy repo/path dest-repo --from-instance src --to-instance dst` streams download+upload
- [ ] Verify destination path defaults to source path when not specified
- [ ] Verify `ak migrate --from-instance src --from-repo npm-local --to-repo npm-staging --dry-run` lists artifacts without transferring
- [ ] Verify `ak migrate --from-instance src --from-repo npm-local --to-instance dst --to-repo npm-staging` transfers with progress bar
- [ ] Verify failed individual artifacts are reported but don't stop the batch
- [ ] Verify exit code 1 when any migrations fail
- [ ] Verify `--no-input` skips confirmation prompt
- [ ] Verify all commands respect `--format json/yaml/quiet` output modes