### PR TITLE
feat: interactive TUI dashboard (ak tui)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "cliclack",
  "comfy-table",
  "console 0.15.11",
+ "crossterm 0.28.1",
  "dialoguer",
  "dirs",
  "futures",
@@ -118,6 +119,7 @@ dependencies = [
  "keyring",
  "miette",
  "predicates",
+ "ratatui",
  "reqwest",
  "serde",
  "serde_json",
@@ -249,6 +251,21 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -389,9 +406,23 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -403,7 +434,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -416,7 +447,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -448,6 +479,23 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -456,7 +504,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix",
+ "rustix 1.1.3",
  "winapi",
 ]
 
@@ -467,6 +515,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -541,6 +624,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -801,6 +890,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1035,6 +1126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1173,7 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "web-time",
 ]
 
@@ -1088,9 +1185,31 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console 0.16.2",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1120,6 +1239,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1216,6 +1344,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -1246,6 +1380,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1311,6 +1454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1408,6 +1552,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1667,6 +1817,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +1968,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -1804,7 +1988,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2104,6 +2288,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,10 +2353,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2241,7 +2474,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2251,7 +2484,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.60.2",
 ]
 
@@ -2269,7 +2502,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2574,6 +2807,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,9 +2825,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ keyring = { version = "3", features = ["apple-native", "linux-native"] }
 # Encoding
 base64 = "0.22"
 
+# TUI
+ratatui = "0.29"
+crossterm = { version = "0.28", features = ["event-stream"] }
+
 # Utilities
 dirs = "6"
 url = "2"

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -1,8 +1,783 @@
-use miette::Result;
+use std::io;
 
-use crate::cli::GlobalArgs;
+use artifact_keeper_sdk::{ClientHealthExt, ClientRepositoriesExt};
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use miette::{IntoDiagnostic, Result};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::{DefaultTerminal, Frame};
 
-pub async fn execute(_global: &GlobalArgs) -> Result<()> {
-    eprintln!("ak tui (not yet implemented — will use ratatui)");
+use super::client::build_client;
+use crate::config::AppConfig;
+use crate::output::format_bytes;
+
+// ---------------------------------------------------------------------------
+// Style helpers — eliminate repeated Style::default().fg(...).add_modifier(...)
+// ---------------------------------------------------------------------------
+
+fn bold_style() -> Style {
+    Style::default().add_modifier(Modifier::BOLD)
+}
+
+fn hotkey_style() -> Style {
+    Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD)
+}
+
+fn dim_style() -> Style {
+    Style::default().fg(Color::DarkGray)
+}
+
+fn cyan_style() -> Style {
+    Style::default().fg(Color::Cyan)
+}
+
+fn highlight_style() -> Style {
+    Style::default()
+        .bg(Color::DarkGray)
+        .add_modifier(Modifier::BOLD)
+}
+
+fn panel_border_style(active: &Panel, panel: &Panel) -> Style {
+    if active == panel {
+        cyan_style()
+    } else {
+        dim_style()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Span/Line helpers — reduce repetitive span construction
+// ---------------------------------------------------------------------------
+
+/// A status-bar hotkey label like " **q**uit ".
+fn hotkey_span<'a>(key: &'a str, rest: &'a str) -> Vec<Span<'a>> {
+    vec![
+        Span::styled(key, hotkey_style()),
+        Span::raw(rest),
+        Span::raw(" "),
+    ]
+}
+
+/// A "Label:  value" detail line with a bold label.
+fn detail_line(label: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(label.to_owned(), bold_style()),
+        Span::raw(value.to_owned()),
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, PartialEq, Eq)]
+enum Panel {
+    Instances,
+    Repos,
+    Artifacts,
+}
+
+struct InstanceEntry {
+    name: String,
+    url: String,
+    status: String,
+}
+
+struct RepoEntry {
+    key: String,
+    format: String,
+    storage_used: i64,
+}
+
+struct ArtifactEntry {
+    path: String,
+    version: Option<String>,
+    size_bytes: i64,
+    downloads: i64,
+    created: String,
+}
+
+struct App {
+    active_panel: Panel,
+    instances: Vec<InstanceEntry>,
+    instance_state: ListState,
+    repos: Vec<RepoEntry>,
+    repo_state: ListState,
+    artifacts: Vec<ArtifactEntry>,
+    artifact_state: ListState,
+    status_message: String,
+    loading: bool,
+    show_help: bool,
+    detail_view: bool,
+    config: AppConfig,
+    search_query: String,
+    searching: bool,
+}
+
+impl App {
+    fn new(config: AppConfig) -> Self {
+        let instances: Vec<InstanceEntry> = config
+            .instances
+            .iter()
+            .map(|(name, inst)| InstanceEntry {
+                name: name.clone(),
+                url: inst.url.clone(),
+                status: "...".to_string(),
+            })
+            .collect();
+
+        let mut instance_state = ListState::default();
+        if !instances.is_empty() {
+            instance_state.select(Some(0));
+        }
+
+        Self {
+            active_panel: Panel::Instances,
+            instances,
+            instance_state,
+            repos: Vec::new(),
+            repo_state: ListState::default(),
+            artifacts: Vec::new(),
+            artifact_state: ListState::default(),
+            status_message: "Press ? for help".to_string(),
+            loading: false,
+            show_help: false,
+            detail_view: false,
+            config,
+            search_query: String::new(),
+            searching: false,
+        }
+    }
+
+    fn selected_instance(&self) -> Option<&InstanceEntry> {
+        self.instance_state
+            .selected()
+            .and_then(|i| self.instances.get(i))
+    }
+
+    fn selected_repo(&self) -> Option<&RepoEntry> {
+        self.repo_state.selected().and_then(|i| self.repos.get(i))
+    }
+
+    fn selected_artifact(&self) -> Option<&ArtifactEntry> {
+        self.artifact_state
+            .selected()
+            .and_then(|i| self.artifacts.get(i))
+    }
+
+    fn active_list_state_mut(&mut self) -> (&mut ListState, usize) {
+        match self.active_panel {
+            Panel::Instances => (&mut self.instance_state, self.instances.len()),
+            Panel::Repos => (&mut self.repo_state, self.repos.len()),
+            Panel::Artifacts => (&mut self.artifact_state, self.artifacts.len()),
+        }
+    }
+
+    fn move_up(&mut self) {
+        let (state, len) = self.active_list_state_mut();
+        list_prev(state, len);
+    }
+
+    fn move_down(&mut self) {
+        let (state, len) = self.active_list_state_mut();
+        list_next(state, len);
+    }
+
+    fn move_left(&mut self) {
+        match self.active_panel {
+            Panel::Instances => {}
+            Panel::Repos => self.active_panel = Panel::Instances,
+            Panel::Artifacts => self.active_panel = Panel::Repos,
+        }
+    }
+
+    fn move_right(&mut self) {
+        match self.active_panel {
+            Panel::Instances if !self.repos.is_empty() => self.active_panel = Panel::Repos,
+            Panel::Repos if !self.artifacts.is_empty() => self.active_panel = Panel::Artifacts,
+            _ => {}
+        }
+    }
+
+    async fn check_instance_health(&mut self) {
+        for entry in &mut self.instances {
+            let instance = match self.config.instances.get(&entry.name) {
+                Some(i) => i,
+                None => continue,
+            };
+
+            let http_client = match reqwest::ClientBuilder::new()
+                .connect_timeout(std::time::Duration::from_secs(3))
+                .timeout(std::time::Duration::from_secs(5))
+                .build()
+            {
+                Ok(c) => c,
+                Err(_) => {
+                    entry.status = "error".to_string();
+                    continue;
+                }
+            };
+
+            let base_url = format!("{}/api/{}", instance.url, instance.api_version);
+            let client = artifact_keeper_sdk::Client::new_with_client(&base_url, http_client);
+
+            match client.health_check().send().await {
+                Ok(resp) => {
+                    entry.status = format!("{} v{}", resp.status, resp.version);
+                }
+                Err(_) => {
+                    entry.status = "offline".to_string();
+                }
+            }
+        }
+    }
+
+    async fn load_repos(&mut self) {
+        let instance_name = match self.selected_instance() {
+            Some(i) => i.name.clone(),
+            None => return,
+        };
+
+        let instance = match self.config.instances.get(&instance_name) {
+            Some(i) => i,
+            None => return,
+        };
+
+        let client = match build_client(&instance_name, instance, None) {
+            Ok(c) => c,
+            Err(_) => {
+                self.status_message = format!("Failed to connect to {instance_name}");
+                return;
+            }
+        };
+
+        self.loading = true;
+        self.status_message = format!("Loading repos from {instance_name}...");
+
+        match client.list_repositories().per_page(100).send().await {
+            Ok(resp) => {
+                self.repos = resp
+                    .items
+                    .iter()
+                    .map(|r| RepoEntry {
+                        key: r.key.clone(),
+                        format: r.format.clone(),
+                        storage_used: r.storage_used_bytes,
+                    })
+                    .collect();
+
+                self.repo_state = ListState::default();
+                if !self.repos.is_empty() {
+                    self.repo_state.select(Some(0));
+                }
+                self.artifacts.clear();
+                self.artifact_state = ListState::default();
+                self.status_message =
+                    format!("{} repositories in {instance_name}", self.repos.len());
+            }
+            Err(e) => {
+                self.status_message = format!("Failed to load repos: {e}");
+                self.repos.clear();
+            }
+        }
+        self.loading = false;
+    }
+
+    async fn load_artifacts(&mut self) {
+        let instance_name = match self.selected_instance() {
+            Some(i) => i.name.clone(),
+            None => return,
+        };
+
+        let repo_key = match self.selected_repo() {
+            Some(r) => r.key.clone(),
+            None => return,
+        };
+
+        let instance = match self.config.instances.get(&instance_name) {
+            Some(i) => i,
+            None => return,
+        };
+
+        let client = match build_client(&instance_name, instance, None) {
+            Ok(c) => c,
+            Err(_) => {
+                self.status_message = format!("Failed to connect to {instance_name}");
+                return;
+            }
+        };
+
+        self.loading = true;
+        self.status_message = format!("Loading artifacts from {repo_key}...");
+
+        let mut req = client.list_artifacts().key(&repo_key).per_page(50);
+        if !self.search_query.is_empty() {
+            req = req.q(&self.search_query);
+        }
+
+        match req.send().await {
+            Ok(resp) => {
+                self.artifacts = resp
+                    .items
+                    .iter()
+                    .map(|a| ArtifactEntry {
+                        path: a.path.clone(),
+                        version: a.version.clone(),
+                        size_bytes: a.size_bytes,
+                        downloads: a.download_count,
+                        created: a.created_at.format("%Y-%m-%d").to_string(),
+                    })
+                    .collect();
+
+                self.artifact_state = ListState::default();
+                if !self.artifacts.is_empty() {
+                    self.artifact_state.select(Some(0));
+                }
+                self.status_message = format!("{} artifacts in {repo_key}", self.artifacts.len());
+            }
+            Err(e) => {
+                self.status_message = format!("Failed to load artifacts: {e}");
+                self.artifacts.clear();
+            }
+        }
+        self.loading = false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// List navigation
+// ---------------------------------------------------------------------------
+
+fn list_next(state: &mut ListState, len: usize) {
+    if len == 0 {
+        return;
+    }
+    let i = match state.selected() {
+        Some(i) => (i + 1).min(len - 1),
+        None => 0,
+    };
+    state.select(Some(i));
+}
+
+fn list_prev(state: &mut ListState, len: usize) {
+    if len == 0 {
+        return;
+    }
+    let i = match state.selected() {
+        Some(i) => i.saturating_sub(1),
+        None => 0,
+    };
+    state.select(Some(i));
+}
+
+// ---------------------------------------------------------------------------
+// Entry point & event loop
+// ---------------------------------------------------------------------------
+
+pub async fn execute(_global: &crate::cli::GlobalArgs) -> Result<()> {
+    let config = AppConfig::load()?;
+
+    if config.instances.is_empty() {
+        eprintln!("No instances configured. Run `ak instance add <name> <url>` first.");
+        return Ok(());
+    }
+
+    enable_raw_mode().into_diagnostic()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen).into_diagnostic()?;
+
+    let terminal = ratatui::init();
+    let result = run_app(terminal, config).await;
+
+    disable_raw_mode().ok();
+    execute!(io::stdout(), LeaveAlternateScreen).ok();
+    ratatui::restore();
+
+    result
+}
+
+async fn run_app(mut terminal: DefaultTerminal, config: AppConfig) -> Result<()> {
+    let mut app = App::new(config);
+
+    app.check_instance_health().await;
+    app.load_repos().await;
+
+    loop {
+        terminal.draw(|f| draw(f, &mut app)).into_diagnostic()?;
+
+        if !event::poll(std::time::Duration::from_millis(100)).into_diagnostic()? {
+            continue;
+        }
+
+        let Event::Key(key) = event::read().into_diagnostic()? else {
+            continue;
+        };
+
+        if app.searching {
+            match key.code {
+                KeyCode::Enter => {
+                    app.searching = false;
+                    app.load_artifacts().await;
+                }
+                KeyCode::Esc => {
+                    app.searching = false;
+                    app.search_query.clear();
+                }
+                KeyCode::Backspace => {
+                    app.search_query.pop();
+                }
+                KeyCode::Char(c) => {
+                    app.search_query.push(c);
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        if app.show_help {
+            app.show_help = false;
+            continue;
+        }
+
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Char('Q') => break,
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => break,
+            KeyCode::Char('?') => app.show_help = true,
+            KeyCode::Char('k') | KeyCode::Up => app.move_up(),
+            KeyCode::Char('j') | KeyCode::Down => app.move_down(),
+            KeyCode::Char('h') | KeyCode::Left => app.move_left(),
+            KeyCode::Char('l') | KeyCode::Right => app.move_right(),
+            KeyCode::Char('/') => {
+                app.searching = true;
+                app.search_query.clear();
+            }
+            KeyCode::Char('i') => {
+                app.detail_view = !app.detail_view;
+            }
+            KeyCode::Tab => {
+                app.active_panel = match app.active_panel {
+                    Panel::Instances => Panel::Repos,
+                    Panel::Repos => Panel::Artifacts,
+                    Panel::Artifacts => Panel::Instances,
+                };
+            }
+            KeyCode::Enter => match app.active_panel {
+                Panel::Instances => {
+                    app.load_repos().await;
+                    if !app.repos.is_empty() {
+                        app.active_panel = Panel::Repos;
+                    }
+                }
+                Panel::Repos => {
+                    app.load_artifacts().await;
+                    if !app.artifacts.is_empty() {
+                        app.active_panel = Panel::Artifacts;
+                    }
+                }
+                Panel::Artifacts => {
+                    app.detail_view = !app.detail_view;
+                }
+            },
+            KeyCode::Char('r') => {
+                app.check_instance_health().await;
+                if app.active_panel == Panel::Repos || app.active_panel == Panel::Artifacts {
+                    app.load_repos().await;
+                }
+                app.status_message = "Refreshed".to_string();
+            }
+            _ => {}
+        }
+    }
+
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Drawing
+// ---------------------------------------------------------------------------
+
+fn draw(f: &mut Frame, app: &mut App) {
+    let size = f.area();
+
+    let main_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(5), Constraint::Length(1)])
+        .split(size);
+
+    if app.detail_view {
+        draw_detail(f, app, main_layout[0]);
+    } else {
+        draw_panels(f, app, main_layout[0]);
+    }
+
+    draw_status_bar(f, app, main_layout[1]);
+
+    if app.show_help {
+        draw_help_overlay(f, size);
+    }
+}
+
+/// Render a list panel with a titled border, highlight, and stateful selection.
+fn render_panel(
+    f: &mut Frame,
+    title: &str,
+    items: Vec<ListItem>,
+    border_style: Style,
+    state: &mut ListState,
+    area: Rect,
+) {
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(border_style);
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(highlight_style())
+        .highlight_symbol("> ");
+
+    f.render_stateful_widget(list, area, state);
+}
+
+fn draw_panels(f: &mut Frame, app: &mut App, area: Rect) {
+    let panels = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(35),
+            Constraint::Percentage(40),
+        ])
+        .split(area);
+
+    // Instances panel
+    let instance_items: Vec<ListItem> = app
+        .instances
+        .iter()
+        .map(|inst| {
+            let status_color = instance_status_color(&inst.status);
+            ListItem::new(Line::from(vec![
+                Span::raw(&inst.name),
+                Span::raw(" "),
+                Span::styled(&inst.status, Style::default().fg(status_color)),
+            ]))
+        })
+        .collect();
+
+    render_panel(
+        f,
+        " Instances ",
+        instance_items,
+        panel_border_style(&app.active_panel, &Panel::Instances),
+        &mut app.instance_state,
+        panels[0],
+    );
+
+    // Repos panel
+    let repo_items: Vec<ListItem> = app
+        .repos
+        .iter()
+        .map(|r| {
+            ListItem::new(Line::from(vec![
+                Span::raw(&r.key),
+                Span::raw(" "),
+                Span::styled(format!("({})", r.format), dim_style()),
+                Span::raw(" "),
+                Span::styled(format_bytes(r.storage_used), cyan_style()),
+            ]))
+        })
+        .collect();
+
+    render_panel(
+        f,
+        " Repositories ",
+        repo_items,
+        panel_border_style(&app.active_panel, &Panel::Repos),
+        &mut app.repo_state,
+        panels[1],
+    );
+
+    // Artifacts panel
+    let artifact_items: Vec<ListItem> = app
+        .artifacts
+        .iter()
+        .map(|a| {
+            let version = a.version.as_deref().unwrap_or("");
+            ListItem::new(Line::from(vec![
+                Span::raw(&a.path),
+                Span::raw(" "),
+                Span::styled(version, Style::default().fg(Color::Yellow)),
+                Span::raw(" "),
+                Span::styled(format_bytes(a.size_bytes), dim_style()),
+            ]))
+        })
+        .collect();
+
+    let artifacts_title = if app.searching {
+        format!(" Artifacts [/{}] ", app.search_query)
+    } else {
+        " Artifacts ".to_string()
+    };
+
+    render_panel(
+        f,
+        &artifacts_title,
+        artifact_items,
+        panel_border_style(&app.active_panel, &Panel::Artifacts),
+        &mut app.artifact_state,
+        panels[2],
+    );
+}
+
+fn draw_detail(f: &mut Frame, app: &mut App, area: Rect) {
+    let layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    // Left: artifact list
+    let items: Vec<ListItem> = app
+        .artifacts
+        .iter()
+        .map(|a| {
+            let version = a.version.as_deref().unwrap_or("");
+            ListItem::new(format!("{} {}", a.path, version))
+        })
+        .collect();
+
+    render_panel(
+        f,
+        " Artifacts ",
+        items,
+        cyan_style(),
+        &mut app.artifact_state,
+        layout[0],
+    );
+
+    // Right: detail
+    let detail = if let Some(a) = app.selected_artifact() {
+        let instance = app
+            .selected_instance()
+            .map(|i| i.name.as_str())
+            .unwrap_or("-");
+        let repo = app.selected_repo().map(|r| r.key.as_str()).unwrap_or("-");
+        vec![
+            detail_line("Path:      ", &a.path),
+            detail_line("Version:   ", a.version.as_deref().unwrap_or("-")),
+            detail_line("Size:      ", &format_bytes(a.size_bytes)),
+            detail_line("Downloads: ", &a.downloads.to_string()),
+            detail_line("Created:   ", &a.created),
+            Line::from(""),
+            detail_line("Instance:  ", instance),
+            detail_line("Repo:      ", repo),
+        ]
+    } else {
+        vec![Line::from("No artifact selected")]
+    };
+
+    let detail_block = Block::default()
+        .title(" Details ")
+        .borders(Borders::ALL)
+        .border_style(cyan_style());
+
+    let detail_widget = Paragraph::new(detail)
+        .block(detail_block)
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(detail_widget, layout[1]);
+}
+
+fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
+    let loading_indicator = if app.loading { " [loading] " } else { "" };
+
+    let mut spans: Vec<Span> = Vec::new();
+    spans.extend(hotkey_span(" q", "uit"));
+    spans.extend(hotkey_span("/", "search"));
+    spans.extend(hotkey_span("i", "nfo"));
+    spans.extend(hotkey_span("r", "efresh"));
+    spans.extend(hotkey_span("?", "help"));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(&app.status_message, dim_style()));
+    spans.push(Span::styled(loading_indicator, cyan_style()));
+
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_help_overlay(f: &mut Frame, area: Rect) {
+    let help_area = centered_rect(60, 70, area);
+
+    let help_text = vec![
+        Line::from(Span::styled("Keyboard Shortcuts", hotkey_style())),
+        Line::from(""),
+        Line::from("  h/Left      Move to left panel"),
+        Line::from("  l/Right     Move to right panel"),
+        Line::from("  j/Down      Move down in list"),
+        Line::from("  k/Up        Move up in list"),
+        Line::from("  Enter       Select / expand"),
+        Line::from("  Tab         Cycle panels"),
+        Line::from(""),
+        Line::from("  /           Search artifacts"),
+        Line::from("  i           Toggle detail view"),
+        Line::from("  r           Refresh data"),
+        Line::from("  ?           Toggle this help"),
+        Line::from("  q           Quit"),
+        Line::from("  Ctrl+C      Quit"),
+        Line::from(""),
+        Line::from(Span::styled("Press any key to close", dim_style())),
+    ];
+
+    let help_block = Block::default()
+        .title(" Help ")
+        .borders(Borders::ALL)
+        .border_style(cyan_style());
+
+    let help = Paragraph::new(help_text)
+        .block(help_block)
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(Clear, help_area);
+    f.render_widget(help, help_area);
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+fn instance_status_color(status: &str) -> Color {
+    if status.starts_with("healthy") {
+        Color::Green
+    } else if status == "offline" || status == "error" {
+        Color::Red
+    } else if status == "..." {
+        Color::DarkGray
+    } else {
+        Color::Yellow
+    }
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
 }


### PR DESCRIPTION
## Summary

- Implement full-screen interactive TUI dashboard using ratatui + crossterm
- Three-panel layout: instances (with health status), repositories (with format/storage), artifacts (with version/size)
- Vim-style keyboard navigation (hjkl, arrows, Tab to cycle panels, Enter to drill down)
- Artifact detail view toggle (i key) showing path, version, size, downloads, date, instance, and repo
- Fuzzy search within repositories (/ key with live query input)
- Help overlay (? key) listing all keyboard shortcuts
- Instance health checks on startup with colored status indicators (green/yellow/red)
- Async data fetching with loading state tracking
- Refresh support (r key) to re-check health and reload data

## Test plan

- [ ] Verify `ak tui` launches the full-screen TUI when instances are configured
- [ ] Verify graceful message when no instances are configured
- [ ] Verify hjkl and arrow keys navigate within lists
- [ ] Verify Tab cycles between panels
- [ ] Verify Enter drills into repos from instances, artifacts from repos
- [ ] Verify h/Left moves back to previous panel
- [ ] Verify / enters search mode and filters artifacts on Enter
- [ ] Verify Esc cancels search
- [ ] Verify i toggles detail view for selected artifact
- [ ] Verify r refreshes health status and data
- [ ] Verify ? shows help overlay, any key dismisses it
- [ ] Verify q and Ctrl+C cleanly exit the TUI
- [ ] Verify terminal is properly restored after exit (raw mode disabled, alternate screen left)