### PR TITLE
feat: distribution packaging (release CI, installer, Docker, Snap)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.github/
+.beads/
+*.md
+LICENSE
+snap/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: ak-linux-amd64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: ak-linux-arm64
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: ak-darwin-amd64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: ak-darwin-arm64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: ak-windows-amd64.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Rename binary (unix)
+        if: runner.os != 'Windows'
+        run: |
+          cp target/${{ matrix.target }}/release/ak ${{ matrix.artifact }}
+          chmod +x ${{ matrix.artifact }}
+
+      - name: Rename binary (windows)
+        if: runner.os == 'Windows'
+        run: cp target/${{ matrix.target }}/release/ak.exe ${{ matrix.artifact }}
+
+      - name: Generate SHA256 checksum
+        shell: bash
+        run: |
+          if command -v sha256sum &> /dev/null; then
+            sha256sum ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
+          else
+            shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            ${{ matrix.artifact }}
+            ${{ matrix.artifact }}.sha256
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/ak-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1.85-slim AS builder
+
+WORKDIR /build
+COPY . .
+
+RUN cargo build --release && \
+    strip target/release/ak
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/ak /usr/local/bin/ak
+
+ENTRYPOINT ["ak"]

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Artifact Keeper CLI installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/artifact-keeper/artifact-keeper-cli/main/install.sh | sh
+set -e
+
+REPO="artifact-keeper/artifact-keeper-cli"
+BINARY_NAME="ak"
+
+# Detect OS
+OS="$(uname -s)"
+case "$OS" in
+  Linux*)  OS_NAME="linux";;
+  Darwin*) OS_NAME="darwin";;
+  MINGW*|MSYS*|CYGWIN*) OS_NAME="windows";;
+  *)
+    echo "Error: Unsupported operating system: $OS" >&2
+    exit 1
+    ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) ARCH_NAME="amd64";;
+  aarch64|arm64) ARCH_NAME="arm64";;
+  *)
+    echo "Error: Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+# Determine artifact name
+if [ "$OS_NAME" = "windows" ]; then
+  ARTIFACT="ak-${OS_NAME}-${ARCH_NAME}.exe"
+else
+  ARTIFACT="ak-${OS_NAME}-${ARCH_NAME}"
+fi
+
+# Get latest release tag
+echo "Detecting latest release..."
+LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+
+if [ -z "$LATEST_TAG" ]; then
+  echo "Error: Could not determine latest release" >&2
+  exit 1
+fi
+
+echo "Latest release: ${LATEST_TAG}"
+
+# Download binary and checksum
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}/${ARTIFACT}"
+CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Downloading ${ARTIFACT}..."
+curl -fsSL "$DOWNLOAD_URL" -o "${TMPDIR}/${ARTIFACT}"
+curl -fsSL "$CHECKSUM_URL" -o "${TMPDIR}/${ARTIFACT}.sha256"
+
+# Verify checksum
+echo "Verifying checksum..."
+cd "$TMPDIR"
+if command -v sha256sum > /dev/null 2>&1; then
+  sha256sum -c "${ARTIFACT}.sha256"
+elif command -v shasum > /dev/null 2>&1; then
+  shasum -a 256 -c "${ARTIFACT}.sha256"
+else
+  echo "Warning: No checksum tool found, skipping verification" >&2
+fi
+cd - > /dev/null
+
+# Determine install directory
+INSTALL_DIR="/usr/local/bin"
+if [ ! -w "$INSTALL_DIR" ] 2>/dev/null; then
+  INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+fi
+
+# Install
+echo "Installing to ${INSTALL_DIR}/${BINARY_NAME}..."
+cp "${TMPDIR}/${ARTIFACT}" "${INSTALL_DIR}/${BINARY_NAME}"
+chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+
+echo ""
+echo "Artifact Keeper CLI (${LATEST_TAG}) installed to ${INSTALL_DIR}/${BINARY_NAME}"
+
+# Check if install dir is in PATH
+case ":$PATH:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    echo ""
+    echo "Note: ${INSTALL_DIR} is not in your PATH."
+    echo "Add it with: export PATH=\"${INSTALL_DIR}:\$PATH\""
+    ;;
+esac
+
+echo ""
+echo "Get started:"
+echo "  ak instance add myserver https://your-registry.example.com"
+echo "  ak auth login"
+echo "  ak repo list"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: ak
+version: git
+summary: Artifact Keeper CLI — manage artifacts, repositories, and registries
+description: |
+  The official CLI/TUI for Artifact Keeper, an enterprise artifact registry
+  supporting 45+ package formats. Browse repositories, upload/download artifacts,
+  run security scans, manage users, and more from the command line.
+
+base: core22
+confinement: classic
+grade: stable
+
+parts:
+  ak:
+    plugin: rust
+    source: .
+    build-packages:
+      - pkg-config
+      - libssl-dev
+
+apps:
+  ak:
+    command: bin/ak


### PR DESCRIPTION
## Summary

- Add release CI workflow that cross-compiles for 5 targets (linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64) with SHA256 checksums and GitHub Releases publishing on tag push
- Add `install.sh` curl installer with OS/architecture detection, checksum verification, and PATH-aware installation to `/usr/local/bin` or `~/.local/bin`
- Add multi-stage Dockerfile for minimal CI pipeline image (`debian:bookworm-slim` base)
- Add Snap packaging with `snapcraft.yaml` (classic confinement)
- Add `.dockerignore` for lean Docker builds

## Test plan

- [ ] Verify release workflow triggers on `v*` tags
- [ ] Verify binaries are built for all 5 target platforms
- [ ] Verify SHA256 checksums are generated alongside binaries
- [ ] Verify `install.sh` detects OS and architecture correctly
- [ ] Verify `install.sh` verifies checksum after download
- [ ] Verify `install.sh` falls back to `~/.local/bin` without sudo
- [ ] Verify `docker build .` produces a working image
- [ ] Verify `docker run ak --help` works
- [ ] Verify `snapcraft.yaml` is valid