### PR TITLE
Add shell completions, man pages, and help examples

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,51 @@ jobs:
             ${{ matrix.artifact }}
             ${{ matrix.artifact }}.sha256
 
+  completions:
+    name: Generate Completions & Man Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build CLI
+        run: cargo build --release
+
+      - name: Generate shell completions
+        run: |
+          mkdir -p completions
+          target/release/ak completion bash > completions/ak.bash
+          target/release/ak completion zsh > completions/_ak
+          target/release/ak completion fish > completions/ak.fish
+          target/release/ak completion powershell > completions/_ak.ps1
+
+      - name: Generate man pages
+        run: |
+          mkdir -p man
+          target/release/ak man-pages man/
+
+      - name: Create completions archive
+        run: tar czf ak-completions.tar.gz -C completions .
+
+      - name: Create man pages archive
+        run: tar czf ak-man-pages.tar.gz -C man .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ak-completions
+          path: ak-completions.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ak-man-pages
+          path: ak-man-pages.tar.gz
+
   release:
     name: Create Release
-    needs: build
+    needs: [build, completions]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -100,3 +142,5 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/ak-*
+            artifacts/ak-completions.tar.gz
+            artifacts/ak-man-pages.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "clap_mangen",
  "cliclack",
  "comfy-table",
  "console 0.15.11",
@@ -360,6 +361,16 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ea63a92086df93893164221ad4f24142086d535b3a0957b9b9bea2dc86301"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "cliclack"
@@ -1953,6 +1964,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ artifact-keeper-sdk = { path = "sdk" }
 # CLI framework
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4"
+clap_mangen = "0.2"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,45 +56,69 @@ pub enum ColorMode {
 #[derive(Subcommand)]
 pub enum Command {
     /// Authenticate with an Artifact Keeper instance
+    #[command(
+        after_help = "Examples:\n  ak auth login\n  ak auth login https://registry.company.com\n  ak auth login --token\n  ak auth whoami\n  ak auth logout"
+    )]
     Auth {
         #[command(subcommand)]
         command: commands::auth::AuthCommand,
     },
 
     /// Manage Artifact Keeper instances (servers)
+    #[command(
+        after_help = "Examples:\n  ak instance add prod https://registry.company.com\n  ak instance list\n  ak instance use prod\n  ak instance info"
+    )]
     Instance {
         #[command(subcommand)]
         command: commands::instance::InstanceCommand,
     },
 
     /// Browse and manage repositories
+    #[command(
+        after_help = "Examples:\n  ak repo list\n  ak repo list --format npm\n  ak repo show my-npm-repo\n  ak repo create my-pypi --format pypi --type local"
+    )]
     Repo {
         #[command(subcommand)]
         command: commands::repo::RepoCommand,
     },
 
     /// Upload, download, search, and manage artifacts
+    #[command(
+        after_help = "Examples:\n  ak artifact push my-repo ./package-1.0.tar.gz\n  ak artifact pull my-repo org/pkg/1.0/pkg-1.0.jar -o pkg.jar\n  ak artifact list my-repo\n  ak artifact search \"log4j\" --format maven\n  ak artifact copy src-repo/path dst-repo/path\n  ak artifact copy src/path dst/path --from-instance staging --to-instance prod"
+    )]
     Artifact {
         #[command(subcommand)]
         command: commands::artifact::ArtifactCommand,
     },
 
     /// Configure local package managers to use Artifact Keeper
+    #[command(
+        after_help = "Examples:\n  ak setup auto\n  ak setup npm --repo my-npm-repo\n  ak setup pip\n  ak setup docker\n  ak setup maven --repo libs-release"
+    )]
     Setup {
         #[command(subcommand)]
         command: commands::setup::SetupCommand,
     },
 
     /// Trigger and view security scan results
+    #[command(
+        after_help = "Examples:\n  ak scan run my-repo org/pkg/1.0/pkg.jar\n  ak scan list --repo my-repo\n  ak scan show <scan-id>"
+    )]
     Scan {
         #[command(subcommand)]
         command: commands::scan::ScanCommand,
     },
 
     /// Diagnose configuration and connectivity issues
+    #[command(
+        after_help = "Runs diagnostics:\n  - Config file readability\n  - Instance connectivity\n  - Auth token validity\n  - Package manager detection"
+    )]
     Doctor,
 
     /// Migrate artifacts between instances in bulk
+    #[command(
+        after_help = "Examples:\n  ak migrate --from-instance staging --from-repo libs --to-repo libs-prod --dry-run\n  ak migrate --from-instance old --from-repo npm --to-instance new --to-repo npm"
+    )]
     Migrate {
         /// Source instance name
         #[arg(long)]
@@ -118,24 +142,46 @@ pub enum Command {
     },
 
     /// Administrative operations (backup, cleanup, users, plugins)
+    #[command(
+        after_help = "Examples:\n  ak admin backup list\n  ak admin backup create --type full\n  ak admin cleanup --audit-logs --old-backups\n  ak admin metrics\n  ak admin users list\n  ak admin plugins list"
+    )]
     Admin {
         #[command(subcommand)]
         command: commands::admin::AdminCommand,
     },
 
     /// Manage CLI configuration
+    #[command(
+        after_help = "Examples:\n  ak config list\n  ak config get default_instance\n  ak config set default_instance prod"
+    )]
     Config {
         #[command(subcommand)]
         command: commands::config::ConfigCommand,
     },
 
     /// Launch interactive TUI dashboard
+    #[command(
+        after_help = "Navigation:\n  hjkl/arrows  Move between panels and items\n  Tab          Next panel\n  Enter        Select / drill down\n  i            Toggle detail view\n  /            Search\n  r            Refresh\n  ?            Help\n  q            Quit"
+    )]
     Tui,
 
     /// Generate shell completions
+    #[command(
+        after_help = "Examples:\n  ak completion bash > ~/.bash_completion.d/ak\n  ak completion zsh > ~/.zfunc/_ak\n  ak completion fish > ~/.config/fish/completions/ak.fish\n  ak completion powershell > ak.ps1"
+    )]
     Completion {
         /// Shell to generate completions for
         shell: Shell,
+    },
+
+    /// Generate man pages
+    #[command(
+        after_help = "Examples:\n  ak man-pages ./man\n  sudo cp man/*.1 /usr/local/share/man/man1/"
+    )]
+    ManPages {
+        /// Output directory for man pages
+        #[arg(default_value = ".")]
+        dir: String,
     },
 }
 
@@ -155,7 +201,7 @@ impl Cli {
             // via CLI or env, switch from table to JSON.
             let explicitly_set = std::env::var("AK_FORMAT").is_ok()
                 || std::env::args().any(|a| a == "--format" || a.starts_with("--format="));
-            self.format.resolve(explicitly_set).clone()
+            self.format.resolve(explicitly_set)
         };
 
         let global = GlobalArgs {
@@ -193,6 +239,7 @@ impl Cli {
             Command::Config { command } => command.execute(&global).await,
             Command::Tui => commands::tui::execute(&global).await,
             Command::Completion { shell } => commands::completion::execute(shell),
+            Command::ManPages { dir } => commands::completion::generate_man_pages(&dir),
         }
     }
 }

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -1,11 +1,46 @@
+use std::fs;
+use std::path::Path;
+
 use clap::CommandFactory;
 use clap_complete::Shell;
-use miette::Result;
+use miette::{IntoDiagnostic, Result};
 
 use crate::cli::Cli;
 
 pub fn execute(shell: Shell) -> Result<()> {
     let mut cmd = Cli::command();
     clap_complete::generate(shell, &mut cmd, "ak", &mut std::io::stdout());
+    Ok(())
+}
+
+pub fn generate_man_pages(dir: &str) -> Result<()> {
+    let out = Path::new(dir);
+    fs::create_dir_all(out).into_diagnostic()?;
+
+    let cmd = Cli::command();
+
+    write_man_page(&cmd, out, "ak.1")?;
+
+    for sub in cmd.get_subcommands() {
+        let filename = format!("ak-{}.1", sub.get_name());
+        write_man_page(sub, out, &filename)?;
+
+        for nested in sub.get_subcommands() {
+            let filename = format!("ak-{}-{}.1", sub.get_name(), nested.get_name());
+            write_man_page(nested, out, &filename)?;
+        }
+    }
+
+    eprintln!("\nMan pages written to {}/", out.display());
+    Ok(())
+}
+
+fn write_man_page(cmd: &clap::Command, dir: &Path, filename: &str) -> Result<()> {
+    let man = clap_mangen::Man::new(cmd.clone());
+    let mut buf = Vec::new();
+    man.render(&mut buf).into_diagnostic()?;
+    let path = dir.join(filename);
+    fs::write(&path, buf).into_diagnostic()?;
+    eprintln!("Generated {}", path.display());
     Ok(())
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-#[derive(Clone, Debug, clap::ValueEnum)]
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
 pub enum OutputFormat {
     Table,
     Json,
@@ -13,9 +13,9 @@ impl OutputFormat {
     ///
     /// When the user hasn't explicitly set a format (i.e. the default "table" is
     /// in effect) and stdout is not a TTY, switch to JSON for pipe-friendly output.
-    pub fn resolve(&self, explicitly_set: bool) -> &Self {
+    pub fn resolve(self, explicitly_set: bool) -> Self {
         if !explicitly_set && matches!(self, Self::Table) && !console::Term::stdout().is_term() {
-            &Self::Json
+            Self::Json
         } else {
             self
         }


### PR DESCRIPTION
## Summary
- Add `ak man-pages <dir>` command using `clap_mangen` to generate 58 man pages for all commands and subcommands
- Add rich `after_help` examples to all top-level commands (`ak auth`, `ak repo`, `ak artifact`, etc.)
- Add completions and man page generation to release CI workflow (bundled as `.tar.gz` archives in releases)
- Make `OutputFormat` `Copy` for cleaner resolve semantics

Closes #16

## Test plan
- [x] `cargo build` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] `ak man-pages /tmp/test` generates 58 man pages
- [x] `ak completion bash/zsh/fish/powershell` generates valid completions
- [x] `ak auth --help` shows examples section
- [ ] CI checks pass