### PR TITLE
Fix license in README to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,4 @@ See the [CI/CD Integration Guide](https://artifactkeeper.com/docs/guides/ci-cd/)
 
 ## License
 
-Apache-2.0
+MIT


### PR DESCRIPTION
Update license reference in README from Apache-2.0 to MIT to match the LICENSE file.