### PR TITLE
Fix runtime bugs: arg collision, double URL, optional auth

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,7 +75,7 @@ pub enum Command {
 
     /// Browse and manage repositories
     #[command(
-        after_help = "Examples:\n  ak repo list\n  ak repo list --format npm\n  ak repo show my-npm-repo\n  ak repo create my-pypi --format pypi --type local"
+        after_help = "Examples:\n  ak repo list\n  ak repo list --pkg-format npm\n  ak repo show my-npm-repo\n  ak repo create my-pypi --pkg-format pypi --type local"
     )]
     Repo {
         #[command(subcommand)]
@@ -84,7 +84,7 @@ pub enum Command {
 
     /// Upload, download, search, and manage artifacts
     #[command(
-        after_help = "Examples:\n  ak artifact push my-repo ./package-1.0.tar.gz\n  ak artifact pull my-repo org/pkg/1.0/pkg-1.0.jar -o pkg.jar\n  ak artifact list my-repo\n  ak artifact search \"log4j\" --format maven\n  ak artifact copy src-repo/path dst-repo/path\n  ak artifact copy src/path dst/path --from-instance staging --to-instance prod"
+        after_help = "Examples:\n  ak artifact push my-repo ./package-1.0.tar.gz\n  ak artifact pull my-repo org/pkg/1.0/pkg-1.0.jar -o pkg.jar\n  ak artifact list my-repo\n  ak artifact search \"log4j\" --pkg-format maven\n  ak artifact copy src-repo/path dst-repo/path\n  ak artifact copy src/path dst/path --from-instance staging --to-instance prod"
     )]
     Artifact {
         #[command(subcommand)]

--- a/src/commands/artifact.rs
+++ b/src/commands/artifact.rs
@@ -6,7 +6,7 @@ use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 use futures::StreamExt;
 use miette::{IntoDiagnostic, Result};
 
-use super::client::{build_client, client_for};
+use super::client::{build_client, client_for, client_for_optional_auth};
 use crate::cli::GlobalArgs;
 use crate::config::AppConfig;
 use crate::error::AkError;
@@ -91,8 +91,8 @@ pub enum ArtifactCommand {
         repo: Option<String>,
 
         /// Filter by package format
-        #[arg(long)]
-        format: Option<String>,
+        #[arg(long = "pkg-format", id = "pkg_format")]
+        pkg_format: Option<String>,
     },
 
     /// Copy an artifact between repositories (same or cross-instance)
@@ -131,8 +131,8 @@ impl ArtifactCommand {
             Self::Search {
                 query,
                 repo,
-                format,
-            } => search(&query, repo.as_deref(), format.as_deref(), global).await,
+                pkg_format,
+            } => search(&query, repo.as_deref(), pkg_format.as_deref(), global).await,
             Self::Copy {
                 source,
                 destination,
@@ -308,7 +308,7 @@ async fn list(
     per_page: i32,
     global: &GlobalArgs,
 ) -> Result<()> {
-    let client = client_for(global)?;
+    let client = client_for_optional_auth(global)?;
 
     let spinner = output::spinner("Fetching artifacts...");
 
@@ -395,7 +395,7 @@ async fn list(
 }
 
 async fn info(repo: &str, artifact_path: &str, global: &GlobalArgs) -> Result<()> {
-    let client = client_for(global)?;
+    let client = client_for_optional_auth(global)?;
 
     let artifacts = client
         .list_artifacts()
@@ -491,7 +491,7 @@ async fn search(
     format: Option<&str>,
     global: &GlobalArgs,
 ) -> Result<()> {
-    let client = client_for(global)?;
+    let client = client_for_optional_auth(global)?;
 
     let spinner = output::spinner("Searching...");
 

--- a/src/commands/client.rs
+++ b/src/commands/client.rs
@@ -40,9 +40,8 @@ pub fn build_client(
         .build()
         .into_diagnostic()?;
 
-    let base_url = format!("{}/api/{}", instance.url, instance.api_version);
     Ok(artifact_keeper_sdk::Client::new_with_client(
-        &base_url,
+        &instance.url,
         http_client,
     ))
 }
@@ -66,4 +65,29 @@ pub fn authenticated_client(
 pub fn client_for(global: &GlobalArgs) -> Result<artifact_keeper_sdk::Client> {
     let (_, _, client) = authenticated_client(global)?;
     Ok(client)
+}
+
+/// Build an unauthenticated SDK client for the resolved instance.
+///
+/// Falls back to authenticated if credentials are available.
+/// Use this for commands that can work without auth (public repos, etc.).
+pub fn client_for_optional_auth(global: &GlobalArgs) -> Result<artifact_keeper_sdk::Client> {
+    // Try authenticated first, fall back to unauthenticated
+    if let Ok(client) = client_for(global) {
+        return Ok(client);
+    }
+
+    let config = AppConfig::load()?;
+    let (_, instance) = config.resolve_instance(global.instance.as_deref())?;
+
+    let http_client = reqwest::ClientBuilder::new()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .into_diagnostic()?;
+
+    Ok(artifact_keeper_sdk::Client::new_with_client(
+        &instance.url,
+        http_client,
+    ))
 }


### PR DESCRIPTION
## Summary
- **Fix clap panic**: Renamed `--format` to `--pkg-format` on `repo list`, `repo create`, and `artifact search` to avoid type collision with the global `--format` (OutputFormat) arg
- **Fix double URL prefix**: SDK paths already include `/api/v1`, so removed the duplicate prefix from `build_client`
- **Add optional auth**: Read-only commands (`repo list/show/browse`, `artifact list/info/search`) now work without authentication for public repos via `client_for_optional_auth()`

## Test plan
- [x] `ak repo list --instance demo --format table` shows 31 repos
- [x] `ak repo list --instance demo` works without auth
- [x] No clap panic on any subcommand
- [x] `cargo clippy` clean