### PR TITLE
Fix nfpm download URL in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Install nfpm
         run: |
-          curl -sfL https://github.com/goreleaser/nfpm/releases/download/v2.45.0/nfpm_2.45.0_linux_amd64.tar.gz -o /tmp/nfpm.tar.gz
+          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v2.45.0/nfpm_2.45.0_Linux_x86_64.tar.gz" -o /tmp/nfpm.tar.gz
           tar xzf /tmp/nfpm.tar.gz -C /usr/local/bin nfpm
 
       - name: Extract version


### PR DESCRIPTION
Asset naming is nfpm_2.45.0_Linux_x86_64.tar.gz (capital L, x86_64 not amd64).