### PR TITLE
Default setup configs to user home directory

### DIFF
--- a/src/commands/setup/mod.rs
+++ b/src/commands/setup/mod.rs
@@ -406,7 +406,7 @@ async fn setup_npm(repo: Option<&str>, global: &GlobalArgs) -> Result<()> {
         token = ctx.token,
     );
 
-    let npmrc_path = std::env::current_dir().into_diagnostic()?.join(".npmrc");
+    let npmrc_path = home_dir()?.join(".npmrc");
 
     if !confirm_write(&npmrc_path, &npmrc_content, global.no_input)? {
         eprintln!("Skipped npm configuration.");
@@ -734,9 +734,14 @@ async fn setup_nuget(repo: Option<&str>, global: &GlobalArgs) -> Result<()> {
         token = ctx.token,
     );
 
-    let config_path = std::env::current_dir()
-        .into_diagnostic()?
-        .join("nuget.config");
+    let config_path = if cfg!(windows) {
+        config_dir()?.join("NuGet").join("NuGet.Config")
+    } else {
+        home_dir()?
+            .join(".nuget")
+            .join("NuGet")
+            .join("NuGet.Config")
+    };
 
     if !confirm_write(&config_path, &nuget_config, global.no_input)? {
         eprintln!("Skipped NuGet configuration.");


### PR DESCRIPTION
## Summary
- **npm**: write `.npmrc` to `~/` instead of current working directory
- **nuget**: write `NuGet.Config` to `~/.nuget/NuGet/` (Linux/macOS) or `%APPDATA%/NuGet/` (Windows) instead of cwd

All other setup commands (pip, cargo, docker, maven, gradle, go, helm) already wrote to home directory locations. npm and nuget were the only two writing to the project directory, which risks accidentally committing tokens to git.

## Test plan
- [x] `ak setup npm` targets `~/.npmrc`
- [x] `ak setup nuget` targets `~/.nuget/NuGet/NuGet.Config`
- [x] cargo build, fmt, clippy pass