### PR TITLE
Simplify and clean up CLI codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "artifact-keeper-cli"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "artifact-keeper-sdk",
  "assert_cmd",

--- a/src/commands/instance.rs
+++ b/src/commands/instance.rs
@@ -101,11 +101,10 @@ fn remove_instance(name: &str) -> Result<()> {
 
     if config.default_instance.as_deref() == Some(name) {
         config.default_instance = config.instances.keys().next().cloned();
-        match config.default_instance {
-            Some(ref new_default) => {
-                eprintln!("Removed instance '{name}'. Default switched to '{new_default}'.");
-            }
-            None => eprintln!("Removed instance '{name}'. No instances remaining."),
+        if let Some(ref new_default) = config.default_instance {
+            eprintln!("Removed instance '{name}'. Default switched to '{new_default}'.");
+        } else {
+            eprintln!("Removed instance '{name}'. No instances remaining.");
         }
     } else {
         eprintln!("Removed instance '{name}'.");

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -404,8 +404,9 @@ fn parse_severity_filter(filter: Option<&str>) -> Vec<String> {
 
 fn truncate(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
-        return s.to_string();
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max.saturating_sub(3)).collect();
+        format!("{truncated}...")
     }
-    let truncated: String = s.chars().take(max - 3).collect();
-    format!("{truncated}...")
 }

--- a/src/commands/setup/mod.rs
+++ b/src/commands/setup/mod.rs
@@ -102,79 +102,64 @@ impl SetupCommand {
 
 struct DetectedEcosystem {
     name: &'static str,
-    format: &'static str,
     marker: &'static str,
 }
 
 const ECOSYSTEMS: &[DetectedEcosystem] = &[
     DetectedEcosystem {
         name: "npm",
-        format: "npm",
         marker: "package.json",
     },
     DetectedEcosystem {
         name: "pip",
-        format: "pypi",
         marker: "pyproject.toml",
     },
     DetectedEcosystem {
         name: "pip",
-        format: "pypi",
         marker: "requirements.txt",
     },
     DetectedEcosystem {
         name: "pip",
-        format: "pypi",
         marker: "setup.py",
     },
     DetectedEcosystem {
         name: "cargo",
-        format: "cargo",
         marker: "Cargo.toml",
     },
     DetectedEcosystem {
         name: "docker",
-        format: "docker",
         marker: "Dockerfile",
     },
     DetectedEcosystem {
         name: "docker",
-        format: "docker",
         marker: "docker-compose.yml",
     },
     DetectedEcosystem {
         name: "maven",
-        format: "maven",
         marker: "pom.xml",
     },
     DetectedEcosystem {
         name: "gradle",
-        format: "maven",
         marker: "build.gradle",
     },
     DetectedEcosystem {
         name: "gradle",
-        format: "maven",
         marker: "build.gradle.kts",
     },
     DetectedEcosystem {
         name: "go",
-        format: "go",
         marker: "go.mod",
     },
     DetectedEcosystem {
         name: "nuget",
-        format: "nuget",
         marker: "*.csproj",
     },
     DetectedEcosystem {
         name: "nuget",
-        format: "nuget",
         marker: "*.fsproj",
     },
     DetectedEcosystem {
         name: "helm",
-        format: "helm",
         marker: "Chart.yaml",
     },
 ];
@@ -352,7 +337,7 @@ fn sudo_write(path: &Path, content: &str) -> Result<()> {
         .into_diagnostic()?;
 
     if !status.success() {
-        return Err(AkError::ServerError(format!("Failed to write {}", path.display())).into());
+        return Err(AkError::ConfigError(format!("Failed to write {}", path.display())).into());
     }
 
     Ok(())
@@ -531,7 +516,7 @@ async fn setup_docker(repo: Option<&str>, global: &GlobalArgs) -> Result<()> {
 
     if !status.success() {
         return Err(
-            AkError::ServerError("Docker login failed. Check your credentials.".into()).into(),
+            AkError::ConfigError("Docker login failed. Check your credentials.".into()).into(),
         );
     }
 
@@ -706,7 +691,7 @@ async fn setup_helm(repo: Option<&str>, global: &GlobalArgs) -> Result<()> {
         .into_diagnostic()?;
 
     if !status.success() {
-        return Err(AkError::ServerError("helm repo add failed".into()).into());
+        return Err(AkError::ConfigError("helm repo add failed".into()).into());
     }
 
     eprintln!("Helm repository added. Run `helm repo update` to fetch charts.");

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -89,7 +89,6 @@ enum Panel {
 
 struct InstanceEntry {
     name: String,
-    url: String,
     status: String,
 }
 
@@ -138,10 +137,9 @@ impl App {
     fn new(config: AppConfig) -> Self {
         let instances: Vec<InstanceEntry> = config
             .instances
-            .iter()
-            .map(|(name, inst)| InstanceEntry {
+            .keys()
+            .map(|name| InstanceEntry {
                 name: name.clone(),
-                url: inst.url.clone(),
                 status: "...".to_string(),
             })
             .collect();
@@ -1120,14 +1118,11 @@ fn draw_facets_panel(f: &mut Frame, app: &App, area: Rect) {
 // ---------------------------------------------------------------------------
 
 fn instance_status_color(status: &str) -> Color {
-    if status.starts_with("online") {
-        Color::Green
-    } else if status == "offline" || status == "error" {
-        Color::Red
-    } else if status == "..." {
-        Color::DarkGray
-    } else {
-        Color::Yellow
+    match status {
+        s if s.starts_with("online") => Color::Green,
+        "offline" | "error" => Color::Red,
+        "..." => Color::DarkGray,
+        _ => Color::Yellow,
     }
 }
 

--- a/src/config/instances.rs
+++ b/src/config/instances.rs
@@ -1,1 +1,0 @@
-// Instance management helpers — will be expanded in Issue #4

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,4 @@
 pub mod credentials;
-pub mod instances;
 
 use std::path::PathBuf;
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -41,11 +41,6 @@ pub fn render<T: Serialize>(data: &T, format: &OutputFormat, table: Option<Strin
     }
 }
 
-/// Detect if stdout is a terminal (interactive context).
-pub fn is_interactive() -> bool {
-    console::Term::stdout().is_term()
-}
-
 /// Format a byte count as a human-readable string (e.g., "1.5 MB").
 pub fn format_bytes(bytes: i64) -> String {
     const KB: i64 = 1024;


### PR DESCRIPTION
## Summary

- Remove dead code: unused `format` field on `DetectedEcosystem`, empty `config/instances.rs` module, unused `is_interactive()` fn, dead `url` field on TUI `InstanceEntry`
- Simplify control flow: flatten nested `match`/`if-let` patterns in auth, config, doctor, instance, client modules
- Fix error variants: use `ConfigError` instead of `ServerError` for local tool failures in setup (docker, helm, sudo_write)
- Use `saturating_sub` in scan truncate to prevent potential underflow
- Add `#[derive(Default)]` to `DiagResult` replacing manual constructor
- Net: −47 lines

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings -A dead_code` clean
- [x] `cargo test --workspace` passes