### PR TITLE
Add Snap Store publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,3 +331,20 @@ jobs:
           user-name: "github-actions[bot]"
           commit-message: "Update ak formula to ${{ steps.version.outputs.version }}"
           target-branch: main
+
+  snap:
+    name: Publish to Snap Store
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: snapcore/action-build@v1
+        id: build
+
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_TOKEN }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: ak
+name: artifactkeeper
 version: git
 summary: Artifact Keeper CLI — manage artifacts, repositories, and registries
 description: |


### PR DESCRIPTION
## Summary

- Rename snap package from `ak` to `artifactkeeper` (the registered Snap Store name)
- Add a `snap` job to the release workflow that builds and publishes to the Snap Store after the GitHub release is created

## Setup required

1. Add `SNAP_STORE_TOKEN` secret to the repo (generated via `snapcraft export-login`)
2. Classic confinement approval from the Snap team (post at https://forum.snapcraft.io/c/store-requests)

## Test plan

- [ ] Add `SNAP_STORE_TOKEN` secret to repo settings
- [ ] Request classic confinement approval on the Snap forum
- [ ] Tag a release and verify the snap job runs successfully
- [ ] Verify `snap install artifactkeeper --classic` works