### PR TITLE
Add SonarCloud scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
+  sonar:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   # Cross-platform build smoke test
   build:
     name: Build (${{ matrix.os }})

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=artifact-keeper_artifact-keeper-cli
+sonar.organization=artifact-keeper
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=**/*test*.rs,**/*tests*.rs
+sonar.exclusions=target/**,sdk/**
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

- Add `sonar-project.properties` with project configuration (project key, organization, source/test paths, exclusions for target/ and sdk/)
- Add a SonarCloud scan job to the CI workflow that runs after tests pass, using `SonarSource/sonarqube-scan-action@v5`

## Test plan

- [ ] Verify the `SONAR_TOKEN` secret is configured in the repository settings
- [ ] Confirm the SonarCloud job runs successfully after the test job passes
- [ ] Check that SonarCloud correctly analyzes the `src/` directory and excludes `target/` and `sdk/`