### PR TITLE
fix: update CLI test mocks for new SDK response fields

### DIFF
--- a/src/commands/admin.rs
+++ b/src/commands/admin.rs
@@ -2485,7 +2485,8 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "audit_logs_deleted": 100,
                 "backups_deleted": 3,
-                "peers_marked_offline": 1
+                "peers_marked_offline": 1,
+                "stale_uploads_deleted": 0
             })))
             .mount(&server)
             .await;
@@ -2878,8 +2879,7 @@ mod tests {
             .and(path("/api/v1/admin/reindex"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "message": "Reindex completed",
-                "artifacts_indexed": 500,
-                "repositories_indexed": 10
+                "status": "completed"
             })))
             .mount(&server)
             .await;
@@ -2928,7 +2928,9 @@ mod tests {
                 "backup_retention_count": 5,
                 "edge_stale_threshold_minutes": 30,
                 "max_upload_size_bytes": 1073741824_i64,
-                "retention_days": 365
+                "retention_days": 365,
+                "storage_backend": "filesystem",
+                "storage_path": "/data/artifacts"
             })))
             .mount(&server)
             .await;
@@ -2952,13 +2954,15 @@ mod tests {
                 "backup_retention_count": 3,
                 "edge_stale_threshold_minutes": 15,
                 "max_upload_size_bytes": 536870912_i64,
-                "retention_days": 180
+                "retention_days": 180,
+                "storage_backend": "filesystem",
+                "storage_path": "/data/artifacts"
             })))
             .mount(&server)
             .await;
 
         let global = crate::test_utils::test_global(OutputFormat::Json);
-        let json_str = r#"{"allow_anonymous_download":true,"audit_retention_days":60,"backup_retention_count":3,"edge_stale_threshold_minutes":15,"max_upload_size_bytes":536870912,"retention_days":180}"#;
+        let json_str = r#"{"allow_anonymous_download":true,"audit_retention_days":60,"backup_retention_count":3,"edge_stale_threshold_minutes":15,"max_upload_size_bytes":536870912,"retention_days":180,"storage_backend":"filesystem","storage_path":"/data/artifacts"}"#;
         let result = update_settings(json_str, &global).await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();

--- a/src/commands/repo.rs
+++ b/src/commands/repo.rs
@@ -789,6 +789,9 @@ mod tests {
             "description": "Test repo",
             "storage_used_bytes": 1024,
             "quota_bytes": null,
+            "upstream_url": null,
+            "upstream_auth_type": null,
+            "upstream_auth_configured": false,
             "created_at": "2026-01-15T12:00:00Z",
             "updated_at": "2026-01-15T12:00:00Z"
         })

--- a/src/commands/snapshots/ak__commands__repo__tests__repo_show_json.snap
+++ b/src/commands/snapshots/ak__commands__repo__tests__repo_show_json.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/repo.rs
-assertion_line: 1025
+assertion_line: 1035
 expression: parsed
 ---
 created_at: "2026-01-15T12:00:00Z"
@@ -14,3 +14,6 @@ quota_bytes: ~
 repo_type: local
 storage_used_bytes: 1024
 updated_at: "2026-01-15T12:00:00Z"
+upstream_auth_configured: false
+upstream_auth_type: ~
+upstream_url: ~

--- a/src/commands/sync_policy.rs
+++ b/src/commands/sync_policy.rs
@@ -1085,6 +1085,7 @@ mod tests {
             created: 3,
             updated: 1,
             removed: 0,
+            retroactive_tasks_queued: 0,
         }
     }
 
@@ -1240,6 +1241,7 @@ mod tests {
             created: 0,
             updated: 0,
             removed: 0,
+            retroactive_tasks_queued: 0,
         };
         let (info, table_str) = format_evaluation_result(&result);
 
@@ -1329,7 +1331,8 @@ mod tests {
             "policies_evaluated": 5,
             "created": 3,
             "updated": 1,
-            "removed": 0
+            "removed": 0,
+            "retroactive_tasks_queued": 0
         })
     }
 


### PR DESCRIPTION
## Summary

Fixes 11 failing tests after the SDK regeneration in #63. The new SDK added
fields to response types that the test mocks were missing.

Fixes:
- `RepositoryResponse`: added `upstream_url`, `upstream_auth_type`, `upstream_auth_configured`
- `EvaluationResultResponse`: added `retroactive_tasks_queued`
- `CleanupResponse`: added `stale_uploads_deleted`
- `ReindexResponse`: replaced old fields with new `status` field
- `SystemSettings`: added `storage_backend`, `storage_path`
- Updated insta snapshot for repo show

All 1380 tests pass.

## Test Checklist
- [x] `cargo test --workspace` passes (1380 tests)
- [x] `cargo clippy` clean