### PR TITLE
fix: replace insecure default passwords in E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
             --network ${{ job.services.postgres.network }} \
             -e DATABASE_URL="postgresql://registry:registry@postgres:5432/artifact_registry_test" \
             -e MEILI_URL="http://meilisearch:7700" \
-            -e ADMIN_PASSWORD="admin123" \
+            -e ADMIN_PASSWORD="TestRunner!2026secure" \
             -e JWT_SECRET="e2e-test-secret-key-not-for-production" \
             -p 8081:8080 \
             ghcr.io/artifact-keeper/artifact-keeper-backend:latest

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -41,7 +41,7 @@ fn get_auth_token() -> &'static str {
             .post(format!("{url}/api/v1/auth/login"))
             .json(&serde_json::json!({
                 "username": "admin",
-                "password": "admin123"
+                "password": "TestRunner!2026secure"
             }))
             .send()
             .expect("Login request failed");

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     environment:
       DATABASE_URL: "postgresql://registry:registry@postgres:5432/artifact_registry_test"
       MEILI_URL: "http://meilisearch:7700"
-      ADMIN_PASSWORD: "admin123"
+      ADMIN_PASSWORD: "TestRunner!2026secure"
       JWT_SECRET: "e2e-test-secret-key-not-for-production"
     ports:
       - "8081:8080"


### PR DESCRIPTION
## Summary

The v1.1.1 backend blocks login with well-known default passwords. Updates E2E test compose and login helper from admin123 to TestRunner!2026secure.

Same fix applied to the backend repo in #639.

## Test Checklist
- [x] No regressions in existing tests

## API Changes
- [x] N/A