### PR TITLE
fix: add windows-native keyring feature for credential persistence on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,10 +1579,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "linux-keyutils",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ miette = { version = "7", features = ["fancy"] }
 thiserror = "2"
 
 # Credential storage
-keyring = { version = "3", features = ["apple-native", "linux-native"] }
+keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 
 # Encoding
 base64 = "0.22"


### PR DESCRIPTION
## Summary

- Add `windows-native` feature to the `keyring` crate so that Windows Credential Manager is used as the native backend for storing login credentials.

Fixes #89

## Background

The `keyring` v3 crate has no default features. Only `apple-native` and `linux-native` were enabled, leaving Windows without any credential store backend. `set_password()` silently returned `Ok` without persisting, causing `ak auth whoami` to fail after a successful `ak auth login`.

## Test plan

- [x] `cargo build --release` succeeds on Windows
- [x] `cargo test --workspace` — 1409 tests pass
- [x] Manual test: `ak auth login` → `ak auth whoami` roundtrip works on Windows 11