### PR TITLE
Fix CLI mutation JSON output, lifecycle create, and stale help/flag examples

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,7 +75,7 @@ pub enum Command {
 
     /// Browse and manage repositories
     #[command(
-        after_help = "Examples:\n  ak repo list\n  ak repo list --pkg-format npm\n  ak repo show my-npm-repo\n  ak repo create my-pypi --pkg-format pypi --type local"
+        after_help = "Examples:\n  ak repo list\n  ak repo list --pkg-format npm\n  ak repo show my-npm-repo\n  ak repo create my-pypi --pkg-format pypi --repo-type local\n  ak repo create pypi-proxy --pkg-format pypi --repo-type remote --upstream-url https://pypi.org"
     )]
     Repo {
         #[command(subcommand)]
@@ -189,7 +189,7 @@ pub enum Command {
 
     /// Manage lifecycle and retention policies
     #[command(
-        after_help = "Examples:\n  ak lifecycle list\n  ak lifecycle show <policy-id>\n  ak lifecycle create my-policy --max-severity high --block-on-fail\n  ak lifecycle preview <policy-id>\n  ak lifecycle execute <policy-id>"
+        after_help = "Examples:\n  ak lifecycle list\n  ak lifecycle show <policy-id>\n  ak lifecycle create cleanup-old --policy-type max_age_days --config '{\"days\": 90}'\n  ak lifecycle create keep-5 --policy-type max_versions --config '{\"keep\": 5}' --repo <repo-id>\n  ak lifecycle preview <policy-id>\n  ak lifecycle execute <policy-id>"
     )]
     Lifecycle {
         #[command(subcommand)]
@@ -198,7 +198,7 @@ pub enum Command {
 
     /// Signing & key management
     #[command(
-        after_help = "Examples:\n  ak sign key list\n  ak sign key create my-key --algorithm ed25519 --type signing --repo <uuid>\n  ak sign config show <repo-id>"
+        after_help = "Examples:\n  ak sign key list\n  ak sign key create my-key --algorithm rsa4096 --type signing --repo <uuid>\n  ak sign config show <repo-id>"
     )]
     Sign {
         #[command(subcommand)]
@@ -234,7 +234,7 @@ pub enum Command {
 
     /// Manage SSO authentication providers (LDAP, OIDC, SAML)
     #[command(
-        after_help = "Examples:\n  ak sso list\n  ak sso show <id> --type oidc\n  ak sso create ldap corp-ldap --server-url ldaps://ldap.corp.com --user-base-dn ou=users,dc=corp\n  ak sso test <id>\n  ak sso toggle <id> --type ldap --enable"
+        after_help = "Examples:\n  ak sso list\n  ak sso show <id> --type oidc\n  ak sso create ldap corp-ldap --server-url ldaps://ldap.corp.com --user-base-dn ou=users,dc=corp\n  ak sso test <id> --type ldap\n  ak sso toggle <id> --type ldap --enable"
     )]
     Sso {
         #[command(subcommand)]
@@ -954,9 +954,10 @@ mod tests {
             "lifecycle",
             "create",
             "my-policy",
-            "--max-severity",
-            "high",
-            "--block-on-fail",
+            "--policy-type",
+            "max_age_days",
+            "--config",
+            "{\"days\": 30}",
         ])
         .unwrap();
         assert!(matches!(cli.command, Command::Lifecycle { .. }));

--- a/src/commands/admin.rs
+++ b/src/commands/admin.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use miette::Result;
 
 use super::client::client_for;
-use super::helpers::{confirm_action, new_table, parse_uuid, sdk_err, short_id};
+use super::helpers::{confirm_action, emit_mutation, new_table, parse_uuid, sdk_err, short_id};
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat, format_bytes};
 
@@ -711,14 +711,14 @@ async fn create_user(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", resp.user.id);
-        return Ok(());
-    }
-
-    eprintln!(
-        "User '{}' created (ID: {}).",
-        resp.user.username, resp.user.id
+    emit_mutation(
+        &*resp,
+        &resp.user.id.to_string(),
+        &format!(
+            "User '{}' created (ID: {}).",
+            resp.user.username, resp.user.id
+        ),
+        global,
     );
 
     if let Some(password) = &resp.generated_password {
@@ -759,7 +759,12 @@ async fn update_user(
         .map_err(|e| sdk_err("update user", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("User '{}' updated (ID: {}).", user.username, user.id);
+    emit_mutation(
+        &*user,
+        &user.id.to_string(),
+        &format!("User '{}' updated (ID: {}).", user.username, user.id),
+        global,
+    );
 
     Ok(())
 }
@@ -787,7 +792,12 @@ async fn delete_user(user_id: &str, skip_confirm: bool, global: &GlobalArgs) -> 
         .map_err(|e| sdk_err("delete user", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("User {user_id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": user_id, "status": "deleted" }),
+        user_id,
+        &format!("User {user_id} deleted."),
+        global,
+    );
 
     Ok(())
 }
@@ -922,7 +932,12 @@ async fn remove_plugin(plugin_id: &str, skip_confirm: bool, global: &GlobalArgs)
         .map_err(|e| sdk_err("remove plugin", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Plugin {plugin_id} removed.");
+    emit_mutation(
+        &serde_json::json!({ "id": plugin_id, "status": "removed" }),
+        plugin_id,
+        &format!("Plugin {plugin_id} removed."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/artifact.rs
+++ b/src/commands/artifact.rs
@@ -7,6 +7,7 @@ use futures::StreamExt;
 use miette::{IntoDiagnostic, Result};
 
 use super::client::{build_client, client_for, client_for_optional_auth};
+use super::helpers::emit_mutation;
 use crate::cli::GlobalArgs;
 use crate::config::AppConfig;
 use crate::error::AkError;
@@ -547,7 +548,12 @@ async fn delete(
         .await
         .map_err(|e| AkError::ServerError(format!("Failed to delete artifact: {e}")))?;
 
-    eprintln!("Deleted '{artifact_path}' from '{repo}'.");
+    emit_mutation(
+        &serde_json::json!({ "repo_key": repo, "path": artifact_path, "status": "deleted" }),
+        artifact_path,
+        &format!("Deleted '{artifact_path}' from '{repo}'."),
+        global,
+    );
     Ok(())
 }
 
@@ -710,9 +716,18 @@ async fn same_instance_copy(
 
     spinner.finish_and_clear();
 
-    eprintln!(
-        "Copied '{}' from '{}' to '{}'.",
-        src_path, src_repo, destination
+    emit_mutation(
+        &serde_json::json!({
+            "source": format!("{src_repo}/{src_path}"),
+            "destination": destination,
+            "status": "copied",
+        }),
+        destination,
+        &format!(
+            "Copied '{}' from '{}' to '{}'.",
+            src_path, src_repo, destination
+        ),
+        global,
     );
 
     Ok(())

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -3,7 +3,9 @@ use clap::Subcommand;
 use miette::Result;
 
 use super::client::client_for;
-use super::helpers::{confirm_action, new_table, parse_uuid, print_page_info, sdk_err, short_id};
+use super::helpers::{
+    confirm_action, emit_mutation, new_table, parse_uuid, print_page_info, sdk_err, short_id,
+};
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
 
@@ -226,12 +228,12 @@ async fn create_group(name: &str, description: Option<&str>, global: &GlobalArgs
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", group.id);
-        return Ok(());
-    }
-
-    eprintln!("Group '{}' created (ID: {}).", group.name, group.id);
+    emit_mutation(
+        &*group,
+        &group.id.to_string(),
+        &format!("Group '{}' created (ID: {}).", group.name, group.id),
+        global,
+    );
 
     Ok(())
 }
@@ -258,7 +260,12 @@ async fn delete_group(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Resu
         .map_err(|e| sdk_err("delete group", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Group {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("Group {id} deleted."),
+        global,
+    );
 
     Ok(())
 }
@@ -283,7 +290,12 @@ async fn add_member(group_id: &str, user_id: &str, global: &GlobalArgs) -> Resul
         .map_err(|e| sdk_err("add member", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Added user {user_id} to group {group_id}.");
+    emit_mutation(
+        &serde_json::json!({ "id": group_id, "user_id": user_id, "status": "added" }),
+        group_id,
+        &format!("Added user {user_id} to group {group_id}."),
+        global,
+    );
 
     Ok(())
 }
@@ -343,7 +355,12 @@ async fn remove_member(group_id: &str, user_id: &str, global: &GlobalArgs) -> Re
         .map_err(|e| sdk_err("remove member", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Removed user {user_id} from group {group_id}.");
+    emit_mutation(
+        &serde_json::json!({ "id": group_id, "user_id": user_id, "status": "removed" }),
+        group_id,
+        &format!("Removed user {user_id} from group {group_id}."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -1,7 +1,10 @@
 use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 use miette::{IntoDiagnostic, Result};
+use serde::Serialize;
 
+use crate::cli::GlobalArgs;
 use crate::error::AkError;
+use crate::output::{self, OutputFormat};
 
 /// Create a new table with the standard preset and headers.
 pub fn new_table(headers: Vec<&str>) -> Table {
@@ -21,6 +24,24 @@ pub fn short_id(id: &uuid::Uuid) -> String {
 /// Map an SDK error to an AkError with a descriptive message.
 pub fn sdk_err(action: &str, e: impl std::fmt::Display) -> AkError {
     AkError::ServerError(format!("Failed to {action}: {e}"))
+}
+
+/// Emit the result of a mutation (create/update/delete) honoring the output
+/// format so results are machine-consumable.
+///
+/// - `Quiet`: prints just the `id` to stdout (for scripting `$(... )` capture).
+/// - `Json`/`Yaml`: renders the full `value` object to **stdout** so callers can
+///   pipe it to `jq` and extract the created/updated ID.
+/// - `Table`: prints the human-readable `human` message to **stderr** (leaving
+///   stdout clean).
+pub fn emit_mutation<T: Serialize>(value: &T, id: &str, human: &str, global: &GlobalArgs) {
+    match global.format {
+        OutputFormat::Quiet => println!("{id}"),
+        OutputFormat::Json | OutputFormat::Yaml => {
+            println!("{}", output::render(value, &global.format, None));
+        }
+        OutputFormat::Table => eprintln!("{human}"),
+    }
 }
 
 /// Parse a string as a UUID, returning a friendly error with the given label.

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use miette::Result;
 
 use super::client::client_for;
-use super::helpers::{new_table, sdk_err};
+use super::helpers::{emit_mutation, new_table, sdk_err};
 use crate::cli::GlobalArgs;
 use crate::error::AkError;
 use crate::output::{self, OutputFormat};
@@ -137,7 +137,17 @@ async fn add_label(repo_key: &str, label: &str, global: &GlobalArgs) -> Result<(
         .map_err(|e| sdk_err("add label", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Label '{label_key}={label_value}' added to repository '{repo_key}'.");
+    emit_mutation(
+        &serde_json::json!({
+            "repo_key": repo_key,
+            "key": label_key,
+            "value": label_value,
+            "status": "added",
+        }),
+        repo_key,
+        &format!("Label '{label_key}={label_value}' added to repository '{repo_key}'."),
+        global,
+    );
 
     Ok(())
 }
@@ -169,7 +179,16 @@ async fn remove_label(repo_key: &str, label_key: &str, global: &GlobalArgs) -> R
         .map_err(|e| sdk_err("remove label", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Label '{label_key}' removed from repository '{repo_key}'.");
+    emit_mutation(
+        &serde_json::json!({
+            "repo_key": repo_key,
+            "key": label_key,
+            "status": "removed",
+        }),
+        repo_key,
+        &format!("Label '{label_key}' removed from repository '{repo_key}'."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/license.rs
+++ b/src/commands/license.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use super::client::client_for;
 use super::helpers::{
-    confirm_action, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
+    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
 };
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
@@ -223,14 +223,14 @@ async fn create_policy(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", policy.id);
-        return Ok(());
-    }
-
-    eprintln!(
-        "License policy '{}' created (ID: {}).",
-        policy.name, policy.id
+    emit_mutation(
+        &*policy,
+        &policy.id.to_string(),
+        &format!(
+            "License policy '{}' created (ID: {}).",
+            policy.name, policy.id
+        ),
+        global,
     );
 
     Ok(())
@@ -258,7 +258,12 @@ async fn delete_policy(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Res
         .map_err(|e| sdk_err("delete license policy", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("License policy {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("License policy {id} deleted."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -2,11 +2,12 @@ use artifact_keeper_sdk::ClientLifecycleExt;
 use clap::Subcommand;
 use miette::Result;
 
-use super::client::client_for;
+use super::client::{client_for, resolve_base_url_and_auth};
 use super::helpers::{
-    confirm_action, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
+    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
 };
 use crate::cli::GlobalArgs;
+use crate::error::AkError;
 use crate::output::{self, OutputFormat, format_bytes};
 
 #[derive(Subcommand)]
@@ -29,33 +30,35 @@ pub enum LifecycleCommand {
         /// Policy name
         name: String,
 
-        /// Maximum vulnerability severity to allow (e.g. critical, high, medium, low)
+        /// Policy type. One of: max_age_days, max_versions, no_downloads_days,
+        /// tag_pattern_keep, tag_pattern_delete, size_quota_bytes
         #[arg(long)]
-        max_severity: String,
+        policy_type: String,
 
-        /// Block artifacts that fail policy checks
+        /// Policy configuration as a JSON object. Required keys by type:
+        /// max_age_days / no_downloads_days => {"days": N};
+        /// max_versions => {"keep": N};
+        /// size_quota_bytes => {"bytes": N};
+        /// tag_pattern_keep / tag_pattern_delete => {"pattern": "<regex>"}
         #[arg(long)]
-        block_on_fail: bool,
+        config: String,
 
-        /// Block unscanned artifacts
+        /// Policy description
         #[arg(long)]
-        block_unscanned: bool,
+        description: Option<String>,
 
-        /// Maximum artifact age in days
+        /// Priority (higher priority policies run first)
         #[arg(long)]
-        max_age_days: Option<i32>,
+        priority: Option<i32>,
 
-        /// Minimum staging time in hours
-        #[arg(long)]
-        min_staging_hours: Option<i32>,
-
-        /// Bind to a specific repository ID
+        /// Bind to a specific repository ID (required for max_versions and
+        /// size_quota_bytes)
         #[arg(long)]
         repo: Option<String>,
 
-        /// Require artifact signatures
+        /// Cron schedule for automatic execution (e.g. "0 2 * * *")
         #[arg(long)]
-        require_signature: bool,
+        cron_schedule: Option<String>,
     },
 
     /// Delete a lifecycle policy
@@ -88,23 +91,21 @@ impl LifecycleCommand {
             Self::Show { id } => show_policy(&id, global).await,
             Self::Create {
                 name,
-                max_severity,
-                block_on_fail,
-                block_unscanned,
-                max_age_days,
-                min_staging_hours,
+                policy_type,
+                config,
+                description,
+                priority,
                 repo,
-                require_signature,
+                cron_schedule,
             } => {
                 create_policy(
                     &name,
-                    &max_severity,
-                    block_on_fail,
-                    block_unscanned,
-                    max_age_days,
-                    min_staging_hours,
+                    &policy_type,
+                    &config,
+                    description.as_deref(),
+                    priority,
                     repo.as_deref(),
-                    require_signature,
+                    cron_schedule.as_deref(),
                     global,
                 )
                 .await
@@ -264,51 +265,113 @@ async fn show_policy(id: &str, global: &GlobalArgs) -> Result<()> {
     Ok(())
 }
 
+/// Valid lifecycle policy types accepted by the backend
+/// (`POST /api/v1/admin/lifecycle`).
+const VALID_POLICY_TYPES: &[&str] = &[
+    "max_age_days",
+    "max_versions",
+    "no_downloads_days",
+    "tag_pattern_keep",
+    "tag_pattern_delete",
+    "size_quota_bytes",
+];
+
 #[allow(clippy::too_many_arguments)]
 async fn create_policy(
     name: &str,
-    max_severity: &str,
-    block_on_fail: bool,
-    block_unscanned: bool,
-    max_age_days: Option<i32>,
-    min_staging_hours: Option<i32>,
+    policy_type: &str,
+    config: &str,
+    description: Option<&str>,
+    priority: Option<i32>,
     repo_id: Option<&str>,
-    require_signature: bool,
+    cron_schedule: Option<&str>,
     global: &GlobalArgs,
 ) -> Result<()> {
+    if !VALID_POLICY_TYPES.contains(&policy_type) {
+        return Err(AkError::ConfigError(format!(
+            "Invalid policy type '{policy_type}'. Must be one of: {}",
+            VALID_POLICY_TYPES.join(", ")
+        ))
+        .into());
+    }
+
+    let config_json: serde_json::Value = serde_json::from_str(config)
+        .map_err(|e| AkError::ConfigError(format!("--config must be a JSON object: {e}")))?;
+    if !config_json.is_object() {
+        return Err(AkError::ConfigError("--config must be a JSON object".into()).into());
+    }
+
     let repository_id = parse_optional_uuid(repo_id, "repository")?;
 
-    let client = client_for(global)?;
+    // The backend's CreatePolicyRequest (name/policy_type/config/...) is not
+    // the shape the generated SDK models, so build the request body directly.
+    let mut body = serde_json::json!({
+        "name": name,
+        "policy_type": policy_type,
+        "config": config_json,
+    });
+    if let Some(d) = description {
+        body["description"] = serde_json::Value::from(d);
+    }
+    if let Some(p) = priority {
+        body["priority"] = serde_json::Value::from(p);
+    }
+    if let Some(rid) = repository_id {
+        body["repository_id"] = serde_json::Value::from(rid.to_string());
+    }
+    if let Some(c) = cron_schedule {
+        body["cron_schedule"] = serde_json::Value::from(c);
+    }
+
+    let (base_url, auth_header) = resolve_base_url_and_auth(global)?;
     let spinner = output::spinner("Creating lifecycle policy...");
 
-    let body = artifact_keeper_sdk::types::CreatePolicyRequest {
-        name: name.to_string(),
-        max_severity: max_severity.to_string(),
-        block_on_fail,
-        block_unscanned: Some(block_unscanned),
-        max_artifact_age_days: max_age_days,
-        min_staging_hours,
-        repository_id,
-        require_signature: require_signature.then_some(true),
-    };
-
-    let policy = client
-        .create_lifecycle_policy()
-        .body(body)
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(format!(
+            "{}/api/v1/admin/lifecycle",
+            base_url.trim_end_matches('/')
+        ))
+        .header(reqwest::header::AUTHORIZATION, auth_header)
+        .json(&body)
         .send()
+        .await
+        .map_err(|e| sdk_err("create lifecycle policy", e))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
         .await
         .map_err(|e| sdk_err("create lifecycle policy", e))?;
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", policy.id);
-        return Ok(());
+    if !status.is_success() {
+        let msg = serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| {
+                v.get("message")
+                    .and_then(|m| m.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or(text);
+        return Err(AkError::ServerError(format!(
+            "create lifecycle policy failed (HTTP {}): {msg}",
+            status.as_u16()
+        ))
+        .into());
     }
 
-    eprintln!(
-        "Lifecycle policy '{}' created (ID: {}).",
-        policy.name, policy.id
+    let policy: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| sdk_err("parse lifecycle policy response", e))?;
+    let id = policy["id"].as_str().unwrap_or_default().to_string();
+    let pname = policy["name"].as_str().unwrap_or(name);
+
+    emit_mutation(
+        &policy,
+        &id,
+        &format!("Lifecycle policy '{pname}' created (ID: {id})."),
+        global,
     );
 
     Ok(())
@@ -336,7 +399,12 @@ async fn delete_policy(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Res
         .map_err(|e| sdk_err("delete lifecycle policy", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Lifecycle policy {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "deleted": true }),
+        id,
+        &format!("Lifecycle policy {id} deleted."),
+        global,
+    );
 
     Ok(())
 }
@@ -546,29 +614,29 @@ mod tests {
         let cli = parse(&[
             "test",
             "create",
-            "security-policy",
-            "--max-severity",
-            "high",
+            "retention-policy",
+            "--policy-type",
+            "max_age_days",
+            "--config",
+            "{\"days\": 90}",
         ]);
         match cli.command {
             LifecycleCommand::Create {
                 name,
-                max_severity,
-                block_on_fail,
-                block_unscanned,
-                max_age_days,
-                min_staging_hours,
+                policy_type,
+                config,
+                description,
+                priority,
                 repo,
-                require_signature,
+                cron_schedule,
             } => {
-                assert_eq!(name, "security-policy");
-                assert_eq!(max_severity, "high");
-                assert!(!block_on_fail);
-                assert!(!block_unscanned);
-                assert!(max_age_days.is_none());
-                assert!(min_staging_hours.is_none());
+                assert_eq!(name, "retention-policy");
+                assert_eq!(policy_type, "max_age_days");
+                assert_eq!(config, "{\"days\": 90}");
+                assert!(description.is_none());
+                assert!(priority.is_none());
                 assert!(repo.is_none());
-                assert!(!require_signature);
+                assert!(cron_schedule.is_none());
             }
             _ => panic!("expected Create"),
         }
@@ -580,37 +648,36 @@ mod tests {
             "test",
             "create",
             "strict-policy",
-            "--max-severity",
-            "critical",
-            "--block-on-fail",
-            "--block-unscanned",
-            "--max-age-days",
-            "90",
-            "--min-staging-hours",
-            "24",
+            "--policy-type",
+            "max_versions",
+            "--config",
+            "{\"keep\": 5}",
+            "--description",
+            "keep latest 5",
+            "--priority",
+            "10",
             "--repo",
             "repo-id",
-            "--require-signature",
+            "--cron-schedule",
+            "0 2 * * *",
         ]);
         match cli.command {
             LifecycleCommand::Create {
                 name,
-                max_severity,
-                block_on_fail,
-                block_unscanned,
-                max_age_days,
-                min_staging_hours,
+                policy_type,
+                config,
+                description,
+                priority,
                 repo,
-                require_signature,
+                cron_schedule,
             } => {
                 assert_eq!(name, "strict-policy");
-                assert_eq!(max_severity, "critical");
-                assert!(block_on_fail);
-                assert!(block_unscanned);
-                assert_eq!(max_age_days, Some(90));
-                assert_eq!(min_staging_hours, Some(24));
+                assert_eq!(policy_type, "max_versions");
+                assert_eq!(config, "{\"keep\": 5}");
+                assert_eq!(description.as_deref(), Some("keep latest 5"));
+                assert_eq!(priority, Some(10));
                 assert_eq!(repo.as_deref(), Some("repo-id"));
-                assert!(require_signature);
+                assert_eq!(cron_schedule.as_deref(), Some("0 2 * * *"));
             }
             _ => panic!("expected Create"),
         }
@@ -618,13 +685,32 @@ mod tests {
 
     #[test]
     fn parse_create_missing_name() {
-        let result = try_parse(&["test", "create", "--max-severity", "high"]);
+        let result = try_parse(&[
+            "test",
+            "create",
+            "--policy-type",
+            "max_age_days",
+            "--config",
+            "{\"days\": 90}",
+        ]);
         assert!(result.is_err());
     }
 
     #[test]
-    fn parse_create_missing_max_severity() {
-        let result = try_parse(&["test", "create", "policy-name"]);
+    fn parse_create_missing_policy_type() {
+        let result = try_parse(&["test", "create", "policy-name", "--config", "{}"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_create_missing_config() {
+        let result = try_parse(&[
+            "test",
+            "create",
+            "policy-name",
+            "--policy-type",
+            "max_age_days",
+        ]);
         assert!(result.is_err());
     }
 
@@ -949,18 +1035,69 @@ mod tests {
         let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
         let result = create_policy(
             "cleanup-old",
-            "high",
-            false,
-            false,
+            "max_age_days",
+            "{\"days\": 90}",
             None,
             None,
             None,
-            false,
+            None,
             &global,
         )
         .await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_create_policy_json() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/admin/lifecycle"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lifecycle_policy_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = create_policy(
+            "cleanup-old",
+            "max_age_days",
+            "{\"days\": 90}",
+            Some("desc"),
+            Some(5),
+            None,
+            None,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_create_policy_invalid_type() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result =
+            create_policy("bad", "not_a_type", "{}", None, None, None, None, &global).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn handler_create_policy_invalid_config() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = create_policy(
+            "bad",
+            "max_age_days",
+            "not-json",
+            None,
+            None,
+            None,
+            None,
+            &global,
+        )
+        .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/commands/peer.rs
+++ b/src/commands/peer.rs
@@ -5,7 +5,7 @@ use miette::Result;
 use serde_json::Value;
 
 use super::client::client_for;
-use super::helpers::{confirm_action, new_table, parse_uuid, sdk_err, short_id};
+use super::helpers::{confirm_action, emit_mutation, new_table, parse_uuid, sdk_err, short_id};
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat, format_bytes};
 
@@ -186,12 +186,12 @@ async fn register_peer(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", peer.id);
-        return Ok(());
-    }
-
-    eprintln!("Peer '{}' registered (ID: {}).", peer.name, peer.id);
+    emit_mutation(
+        &*peer,
+        &peer.id.to_string(),
+        &format!("Peer '{}' registered (ID: {}).", peer.name, peer.id),
+        global,
+    );
 
     Ok(())
 }
@@ -218,7 +218,12 @@ async fn unregister_peer(id: &str, skip_confirm: bool, global: &GlobalArgs) -> R
         .map_err(|e| sdk_err("unregister peer", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Peer {id} unregistered.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "unregistered" }),
+        id,
+        &format!("Peer {id} unregistered."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/permission.rs
+++ b/src/commands/permission.rs
@@ -3,7 +3,9 @@ use clap::Subcommand;
 use miette::Result;
 
 use super::client::client_for;
-use super::helpers::{confirm_action, new_table, parse_uuid, print_page_info, sdk_err};
+use super::helpers::{
+    confirm_action, emit_mutation, new_table, parse_uuid, print_page_info, sdk_err,
+};
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
 
@@ -225,18 +227,18 @@ async fn create_permission(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", perm.id);
-        return Ok(());
-    }
-
-    eprintln!(
-        "Permission created (ID: {}): {} {} on {} {}",
-        perm.id,
-        perm.principal_type,
-        perm.principal_name.as_deref().unwrap_or("?"),
-        perm.target_type,
-        perm.target_name.as_deref().unwrap_or("?"),
+    emit_mutation(
+        &*perm,
+        &perm.id.to_string(),
+        &format!(
+            "Permission created (ID: {}): {} {} on {} {}",
+            perm.id,
+            perm.principal_type,
+            perm.principal_name.as_deref().unwrap_or("?"),
+            perm.target_type,
+            perm.target_name.as_deref().unwrap_or("?"),
+        ),
+        global,
     );
 
     Ok(())
@@ -296,7 +298,12 @@ async fn delete_permission(id: &str, skip_confirm: bool, global: &GlobalArgs) ->
         .map_err(|e| sdk_err("delete permission", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Permission {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("Permission {id} deleted."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -9,7 +9,7 @@ use miette::Result;
 use serde_json::Value;
 
 use super::client::client_for;
-use super::helpers::{new_table, parse_uuid, sdk_err, short_id};
+use super::helpers::{emit_mutation, new_table, parse_uuid, sdk_err, short_id};
 use crate::cli::GlobalArgs;
 use crate::error::AkError;
 use crate::output::{self, OutputFormat};
@@ -155,12 +155,12 @@ async fn update_profile(
         .map_err(|e| sdk_err("update profile", e))?;
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", me.id);
-        return Ok(());
-    }
-
-    eprintln!("Profile updated.");
+    emit_mutation(
+        &serde_json::json!({ "status": "updated" }),
+        "profile",
+        "Profile updated.",
+        global,
+    );
     Ok(())
 }
 
@@ -330,7 +330,12 @@ async fn revoke_token(id: &str, global: &GlobalArgs) -> Result<()> {
         .map_err(|e| sdk_err("revoke API token", e))?;
     spinner.finish_and_clear();
 
-    eprintln!("Token {id} revoked.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "revoked" }),
+        id,
+        &format!("Token {id} revoked."),
+        global,
+    );
     Ok(())
 }
 

--- a/src/commands/promotion.rs
+++ b/src/commands/promotion.rs
@@ -3,7 +3,9 @@ use clap::Subcommand;
 use miette::Result;
 
 use super::client::client_for;
-use super::helpers::{confirm_action, new_table, parse_uuid, print_page_info, sdk_err, short_id};
+use super::helpers::{
+    confirm_action, emit_mutation, new_table, parse_uuid, print_page_info, sdk_err, short_id,
+};
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
 
@@ -293,12 +295,12 @@ async fn create_rule(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", rule.id);
-        return Ok(());
-    }
-
-    eprintln!("Promotion rule '{}' created (ID: {}).", rule.name, rule.id);
+    emit_mutation(
+        &*rule,
+        &rule.id.to_string(),
+        &format!("Promotion rule '{}' created (ID: {}).", rule.name, rule.id),
+        global,
+    );
 
     Ok(())
 }
@@ -325,7 +327,12 @@ async fn delete_rule(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Resul
         .map_err(|e| sdk_err("delete promotion rule", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Promotion rule {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("Promotion rule {id} deleted."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/quality_gate.rs
+++ b/src/commands/quality_gate.rs
@@ -4,7 +4,7 @@ use miette::Result;
 
 use super::client::client_for;
 use super::helpers::{
-    confirm_action, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
+    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
 };
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
@@ -356,12 +356,12 @@ async fn create_gate(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", gate.id);
-        return Ok(());
-    }
-
-    eprintln!("Quality gate '{}' created (ID: {}).", gate.name, gate.id);
+    emit_mutation(
+        &*gate,
+        &gate.id.to_string(),
+        &format!("Quality gate '{}' created (ID: {}).", gate.name, gate.id),
+        global,
+    );
 
     Ok(())
 }
@@ -406,7 +406,12 @@ async fn update_gate(
         .map_err(|e| sdk_err("update quality gate", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Quality gate '{}' updated.", gate.name);
+    emit_mutation(
+        &*gate,
+        &gate.id.to_string(),
+        &format!("Quality gate '{}' updated.", gate.name),
+        global,
+    );
 
     Ok(())
 }
@@ -433,7 +438,12 @@ async fn delete_gate(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Resul
         .map_err(|e| sdk_err("delete quality gate", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Quality gate {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("Quality gate {id} deleted."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/repo.rs
+++ b/src/commands/repo.rs
@@ -4,6 +4,7 @@ use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 use miette::{IntoDiagnostic, Result};
 
 use super::client::{client_for, client_for_optional_auth};
+use super::helpers::emit_mutation;
 use crate::cli::GlobalArgs;
 use crate::error::AkError;
 use crate::output::{self, OutputFormat, format_bytes};
@@ -323,14 +324,14 @@ async fn create_repo(
         .await
         .map_err(|e| AkError::ServerError(format!("Failed to create repository: {e}")))?;
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", resp.key);
-        return Ok(());
-    }
-
-    eprintln!(
-        "Created repository '{}' (format: {}, type: {})",
-        resp.key, resp.format, resp.repo_type
+    emit_mutation(
+        &*resp,
+        &resp.key,
+        &format!(
+            "Created repository '{}' (format: {}, type: {})",
+            resp.key, resp.format, resp.repo_type
+        ),
+        global,
     );
 
     Ok(())
@@ -360,7 +361,12 @@ async fn delete_repo(key: &str, skip_confirm: bool, global: &GlobalArgs) -> Resu
         .await
         .map_err(|e| AkError::ServerError(format!("Failed to delete repository: {e}")))?;
 
-    eprintln!("Deleted repository '{key}'.");
+    emit_mutation(
+        &serde_json::json!({ "key": key, "status": "deleted" }),
+        key,
+        &format!("Deleted repository '{key}'."),
+        global,
+    );
     Ok(())
 }
 

--- a/src/commands/sbom.rs
+++ b/src/commands/sbom.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use super::client::client_for;
 use super::helpers::{
-    confirm_action, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
+    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
 };
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
@@ -434,7 +434,12 @@ async fn delete_sbom(sbom_id: &str, skip_confirm: bool, global: &GlobalArgs) -> 
         .map_err(|e| sdk_err("delete SBOM", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("SBOM {sbom_id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": sbom_id, "status": "deleted" }),
+        sbom_id,
+        &format!("SBOM {sbom_id} deleted."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use super::client::client_for;
 use super::helpers::{
-    confirm_action, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
+    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
 };
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
@@ -1006,25 +1006,12 @@ async fn create_policy(
 
     let p = policy.into_inner();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", p.id);
-        return Ok(());
-    }
-
-    let entry = serde_json::json!({
-        "id": p.id.to_string(),
-        "name": p.name,
-        "max_severity": p.max_severity,
-        "block_on_fail": p.block_on_fail,
-        "block_unscanned": p.block_unscanned,
-        "is_enabled": p.is_enabled,
-    });
-
-    if matches!(global.format, OutputFormat::Json | OutputFormat::Yaml) {
-        println!("{}", output::render(&[entry], &global.format, None));
-    } else {
-        eprintln!("Policy '{}' created (ID: {}).", p.name, short_id(&p.id));
-    }
+    emit_mutation(
+        &p,
+        &p.id.to_string(),
+        &format!("Policy '{}' created (ID: {}).", p.name, short_id(&p.id)),
+        global,
+    );
 
     Ok(())
 }
@@ -1078,25 +1065,12 @@ async fn update_policy(
 
     let p = policy.into_inner();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", p.id);
-        return Ok(());
-    }
-
-    let entry = serde_json::json!({
-        "id": p.id.to_string(),
-        "name": p.name,
-        "max_severity": p.max_severity,
-        "block_on_fail": p.block_on_fail,
-        "block_unscanned": p.block_unscanned,
-        "is_enabled": p.is_enabled,
-    });
-
-    if matches!(global.format, OutputFormat::Json | OutputFormat::Yaml) {
-        println!("{}", output::render(&[entry], &global.format, None));
-    } else {
-        eprintln!("Policy '{}' updated (ID: {}).", p.name, short_id(&p.id));
-    }
+    emit_mutation(
+        &p,
+        &p.id.to_string(),
+        &format!("Policy '{}' updated (ID: {}).", p.name, short_id(&p.id)),
+        global,
+    );
 
     Ok(())
 }
@@ -1120,9 +1094,12 @@ async fn delete_policy(policy_id: &str, yes: bool, global: &GlobalArgs) -> Resul
 
     spinner.finish_and_clear();
 
-    if !matches!(global.format, OutputFormat::Quiet) {
-        eprintln!("Policy {} deleted.", &policy_id);
-    }
+    emit_mutation(
+        &serde_json::json!({ "id": policy_id, "status": "deleted" }),
+        policy_id,
+        &format!("Policy {} deleted.", &policy_id),
+        global,
+    );
 
     Ok(())
 }
@@ -1230,7 +1207,7 @@ async fn update_repo_security(
         severity_threshold: Some(severity_threshold.to_string()),
     };
 
-    let config = client
+    client
         .update_repo_security()
         .key(repo_key)
         .body(body)
@@ -1240,28 +1217,12 @@ async fn update_repo_security(
 
     spinner.finish_and_clear();
 
-    let c = config.into_inner();
-
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", c.id);
-        return Ok(());
-    }
-
-    let entry = serde_json::json!({
-        "id": c.id.to_string(),
-        "repository_id": c.repository_id.to_string(),
-        "scan_enabled": c.scan_enabled,
-        "scan_on_upload": c.scan_on_upload,
-        "scan_on_proxy": c.scan_on_proxy,
-        "block_on_policy_violation": c.block_on_policy_violation,
-        "severity_threshold": c.severity_threshold,
-    });
-
-    if matches!(global.format, OutputFormat::Json | OutputFormat::Yaml) {
-        println!("{}", output::render(&[entry], &global.format, None));
-    } else {
-        eprintln!("Security config updated for repository '{repo_key}'.");
-    }
+    emit_mutation(
+        &serde_json::json!({ "repo_key": repo_key, "status": "updated" }),
+        repo_key,
+        &format!("Security config updated for repository '{repo_key}'."),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/sign.rs
+++ b/src/commands/sign.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use super::client::client_for;
 use super::helpers::{
-    confirm_action, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
+    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
 };
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
@@ -43,8 +43,8 @@ pub enum SignKeyCommand {
         /// Key name
         name: String,
 
-        /// Algorithm (e.g. ed25519, rsa-4096, ecdsa-p256)
-        #[arg(long)]
+        /// Signing algorithm. Supported: rsa2048, rsa4096 (default: rsa4096)
+        #[arg(long, default_value = "rsa4096")]
         algorithm: String,
 
         /// Key type (e.g. signing, encryption)
@@ -297,12 +297,12 @@ async fn create_key(
     let key = key.into_inner();
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", key.id);
-        return Ok(());
-    }
-
-    eprintln!("Signing key '{}' created (ID: {}).", key.name, key.id);
+    emit_mutation(
+        &key,
+        &key.id.to_string(),
+        &format!("Signing key '{}' created (ID: {}).", key.name, key.id),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/sso.rs
+++ b/src/commands/sso.rs
@@ -8,7 +8,7 @@ use miette::Result;
 use serde_json::Value;
 
 use super::client::client_for;
-use super::helpers::{confirm_action, new_table, parse_uuid, sdk_err, short_id};
+use super::helpers::{confirm_action, emit_mutation, new_table, parse_uuid, sdk_err, short_id};
 use crate::cli::GlobalArgs;
 use crate::error::AkError;
 use crate::output::{self, OutputFormat};
@@ -52,6 +52,10 @@ pub enum SsoCommand {
     Test {
         /// Provider ID
         id: String,
+
+        /// Provider type (only 'ldap' supports connectivity testing)
+        #[arg(long, value_parser = ["ldap", "oidc", "saml"], default_value = "ldap")]
+        r#type: String,
     },
 
     /// Enable or disable an SSO provider
@@ -191,7 +195,7 @@ impl SsoCommand {
                 }
             },
             Self::Delete { id, r#type, yes } => delete_provider(&id, &r#type, yes, global).await,
-            Self::Test { id } => test_provider(&id, global).await,
+            Self::Test { id, r#type } => test_provider(&id, &r#type, global).await,
             Self::Toggle { id, r#type, enable } => {
                 toggle_provider(&id, &r#type, enable, global).await
             }
@@ -347,12 +351,12 @@ async fn create_ldap(
     spinner.finish_and_clear();
     let p = resp.into_inner();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", p.id);
-        return Ok(());
-    }
-
-    eprintln!("LDAP provider '{}' created (ID: {}).", p.name, p.id);
+    emit_mutation(
+        &p,
+        &p.id.to_string(),
+        &format!("LDAP provider '{}' created (ID: {}).", p.name, p.id),
+        global,
+    );
     Ok(())
 }
 
@@ -408,12 +412,12 @@ async fn create_oidc(
     spinner.finish_and_clear();
     let p = resp.into_inner();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", p.id);
-        return Ok(());
-    }
-
-    eprintln!("OIDC provider '{}' created (ID: {}).", p.name, p.id);
+    emit_mutation(
+        &p,
+        &p.id.to_string(),
+        &format!("OIDC provider '{}' created (ID: {}).", p.name, p.id),
+        global,
+    );
     Ok(())
 }
 
@@ -454,12 +458,12 @@ async fn create_saml(
     spinner.finish_and_clear();
     let p = resp.into_inner();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", p.id);
-        return Ok(());
-    }
-
-    eprintln!("SAML provider '{}' created (ID: {}).", p.name, p.id);
+    emit_mutation(
+        &p,
+        &p.id.to_string(),
+        &format!("SAML provider '{}' created (ID: {}).", p.name, p.id),
+        global,
+    );
     Ok(())
 }
 
@@ -511,13 +515,30 @@ async fn delete_provider(
     }
 
     spinner.finish_and_clear();
-    eprintln!("Provider {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("Provider {id} deleted."),
+        global,
+    );
 
     Ok(())
 }
 
-async fn test_provider(id: &str, global: &GlobalArgs) -> Result<()> {
+async fn test_provider(id: &str, provider_type: &str, global: &GlobalArgs) -> Result<()> {
     let provider_id = parse_uuid(id, "provider")?;
+
+    // The backend only exposes a connectivity-test endpoint for LDAP providers
+    // (`POST /admin/sso/ldap/{id}/test`); OIDC/SAML have no test route. Reject
+    // those up front with a clear message instead of hitting the LDAP endpoint
+    // (which would 404 for a non-LDAP provider id).
+    if provider_type != "ldap" {
+        return Err(AkError::ConfigError(format!(
+            "Connectivity testing is only supported for LDAP providers, not '{provider_type}'. \
+             OIDC/SAML providers are validated at login time."
+        ))
+        .into());
+    }
 
     let client = client_for(global)?;
     let spinner = output::spinner("Testing LDAP connectivity...");
@@ -1124,8 +1145,20 @@ mod tests {
     #[test]
     fn parse_test() {
         let cli = parse(&["test", "test", "some-id"]);
-        if let SsoCommand::Test { id } = cli.command {
+        if let SsoCommand::Test { id, r#type } = cli.command {
             assert_eq!(id, "some-id");
+            assert_eq!(r#type, "ldap");
+        } else {
+            panic!("Expected Test");
+        }
+    }
+
+    #[test]
+    fn parse_test_with_type() {
+        let cli = parse(&["test", "test", "some-id", "--type", "oidc"]);
+        if let SsoCommand::Test { id, r#type } = cli.command {
+            assert_eq!(id, "some-id");
+            assert_eq!(r#type, "oidc");
         } else {
             panic!("Expected Test");
         }
@@ -1666,9 +1699,18 @@ mod tests {
             .await;
 
         let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
-        let result = test_provider(NIL_UUID, &global).await;
+        let result = test_provider(NIL_UUID, "ldap", &global).await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_test_provider_non_ldap_rejected() {
+        // OIDC/SAML have no backend test endpoint; the CLI should reject early
+        // rather than hitting the LDAP route.
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        assert!(test_provider(NIL_UUID, "oidc", &global).await.is_err());
+        assert!(test_provider(NIL_UUID, "saml", &global).await.is_err());
     }
 
     #[tokio::test]

--- a/src/commands/sync_policy.rs
+++ b/src/commands/sync_policy.rs
@@ -8,7 +8,7 @@ use miette::{Result, miette};
 use serde_json::Value;
 
 use super::client::client_for;
-use super::helpers::{confirm_action, new_table, parse_uuid, sdk_err, short_id};
+use super::helpers::{confirm_action, emit_mutation, new_table, parse_uuid, sdk_err, short_id};
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
 
@@ -315,12 +315,12 @@ async fn create_policy(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", policy.id);
-        return Ok(());
-    }
-
-    eprintln!("Sync policy '{}' created (ID: {}).", policy.name, policy.id);
+    emit_mutation(
+        &*policy,
+        &policy.id.to_string(),
+        &format!("Sync policy '{}' created (ID: {}).", policy.name, policy.id),
+        global,
+    );
 
     Ok(())
 }
@@ -360,12 +360,12 @@ async fn update_policy(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", policy.id);
-        return Ok(());
-    }
-
-    eprintln!("Sync policy '{}' updated.", policy.name);
+    emit_mutation(
+        &*policy,
+        &policy.id.to_string(),
+        &format!("Sync policy '{}' updated.", policy.name),
+        global,
+    );
 
     Ok(())
 }
@@ -392,7 +392,12 @@ async fn delete_policy(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Res
         .map_err(|e| sdk_err("delete sync policy", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Sync policy {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("Sync policy {id} deleted."),
+        global,
+    );
 
     Ok(())
 }
@@ -423,17 +428,17 @@ async fn toggle_policy(id: &str, enable: bool, disable: bool, global: &GlobalArg
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", policy.enabled);
-        return Ok(());
-    }
-
     let state = if policy.enabled {
         "enabled"
     } else {
         "disabled"
     };
-    eprintln!("Sync policy '{}' {state}.", policy.name);
+    emit_mutation(
+        &*policy,
+        &policy.id.to_string(),
+        &format!("Sync policy '{}' {state}.", policy.name),
+        global,
+    );
 
     Ok(())
 }

--- a/src/commands/webhook.rs
+++ b/src/commands/webhook.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use super::client::client_for;
 use super::helpers::{
-    confirm_action, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
+    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
 };
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
@@ -239,12 +239,12 @@ async fn create_webhook(
 
     spinner.finish_and_clear();
 
-    if matches!(global.format, OutputFormat::Quiet) {
-        println!("{}", webhook.id);
-        return Ok(());
-    }
-
-    eprintln!("Webhook '{}' created (ID: {}).", webhook.name, webhook.id);
+    emit_mutation(
+        &*webhook,
+        &webhook.id.to_string(),
+        &format!("Webhook '{}' created (ID: {}).", webhook.name, webhook.id),
+        global,
+    );
 
     Ok(())
 }
@@ -271,7 +271,12 @@ async fn delete_webhook(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Re
         .map_err(|e| sdk_err("delete webhook", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Webhook {id} deleted.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("Webhook {id} deleted."),
+        global,
+    );
 
     Ok(())
 }
@@ -317,7 +322,12 @@ async fn enable_webhook(id: &str, global: &GlobalArgs) -> Result<()> {
         .map_err(|e| sdk_err("enable webhook", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Webhook {id} enabled.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "enabled" }),
+        id,
+        &format!("Webhook {id} enabled."),
+        global,
+    );
 
     Ok(())
 }
@@ -336,7 +346,12 @@ async fn disable_webhook(id: &str, global: &GlobalArgs) -> Result<()> {
         .map_err(|e| sdk_err("disable webhook", e))?;
 
     spinner.finish_and_clear();
-    eprintln!("Webhook {id} disabled.");
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "disabled" }),
+        id,
+        &format!("Webhook {id} disabled."),
+        global,
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes CLI-side broken functionality found in stress testing against the v1.4.0 backend. All changes are targeted edits to existing command files; no new command modules and no SDK regeneration.

### `ak lifecycle create` always returned 422
The command sent a `max_severity`/`block_on_fail` body, but the backend's `POST /api/v1/admin/lifecycle` requires `policy_type` + `config` (retention-style policy). The generated SDK models the stale shape, so the request is now built directly. New flags: `--policy-type`, `--config` (JSON), plus optional `--description`/`--priority`/`--repo`/`--cron-schedule`. Policy type and config JSON are validated client-side, and backend validation errors are surfaced with a clean message.

### Mutation verbs ignored `--format json`
Create/update/delete verbs printed a prose sentence to stderr and nothing to stdout, so scripts could not capture created IDs or pipe to `jq`. A shared `emit_mutation` helper now:
- `--format json`/`yaml`: emits the created/updated object (or a structured result) to **stdout**
- `--format quiet`: prints just the id
- default table: keeps the human message on stderr

Applied across repo, group, license, permission, profile, sync-policy, webhook, promotion, admin (user/plugin), sso, scan, quality-gate, sbom, peer, label, lifecycle, and artifact.

### `sign key create` help/default used an unsupported algorithm
`ed25519` is rejected by the backend (only `rsa2048`/`rsa4096`). The default and help example now use `rsa4096`.

### `sso test` always hit the LDAP endpoint
Added `--type`; only LDAP has a backend connectivity-test route, so OIDC/SAML are now rejected with a clear message instead of a confusing 404.

### `repo create` help showed wrong flags
Examples referenced `--type`/`--url`; corrected to the real `--repo-type`/`--upstream-url`.

## Verification

Built `--release`; `cargo fmt --check`, `cargo clippy --workspace -- -D warnings -A dead_code`, and `cargo test --workspace` (1449 passed) all clean. Each fixed command was re-run against the live v1.4.0 backend and confirmed working (JSON captured via `jq`, IDs captured in quiet mode, lifecycle create returns 200). Test objects created during verification were cleaned up.

## Note on the reported "six commands 404" (F3)
On current `main`, `artifact copy`, `sbom get/components/export`, `license check`, `quality-gate check`, and `scan security show` all reach the correct endpoints and return 200 with valid input — verified live. The stress-test 404s were business-precondition responses (no license policy configured / no enabled quality gate) or a repo UUID passed where a key is expected, not path drift. No path changes were needed for those; they are documented here for the record.
