### PR TITLE
feat(cli): add artifact label command coverage

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,9 +178,9 @@ pub enum Command {
         command: commands::quality_gate::QualityGateCommand,
     },
 
-    /// Tag repositories with key-value labels
+    /// Tag repositories and artifacts with key-value labels
     #[command(
-        after_help = "Examples:\n  ak label repo list my-repo\n  ak label repo add my-repo env=production\n  ak label repo remove my-repo env"
+        after_help = "Examples:\n  ak label repo list my-repo\n  ak label repo add my-repo env=production\n  ak label repo remove my-repo env\n  ak label artifact list <artifact-id>\n  ak label artifact add <artifact-id> env=production\n  ak label artifact set <artifact-id> env=production team=platform\n  ak label artifact remove <artifact-id> env"
     )]
     Label {
         #[command(subcommand)]
@@ -958,6 +958,39 @@ mod tests {
     #[test]
     fn parse_label_repo_remove() {
         let cli = parse(&["ak", "label", "repo", "remove", "my-repo", "env"]).unwrap();
+        assert!(matches!(cli.command, Command::Label { .. }));
+    }
+
+    #[test]
+    fn parse_label_artifact_list() {
+        let cli = parse(&["ak", "label", "artifact", "list", "abc-123"]).unwrap();
+        assert!(matches!(cli.command, Command::Label { .. }));
+    }
+
+    #[test]
+    fn parse_label_artifact_add() {
+        let cli = parse(&["ak", "label", "artifact", "add", "abc-123", "env=prod"]).unwrap();
+        assert!(matches!(cli.command, Command::Label { .. }));
+    }
+
+    #[test]
+    fn parse_label_artifact_set() {
+        let cli = parse(&[
+            "ak",
+            "label",
+            "artifact",
+            "set",
+            "abc-123",
+            "env=prod",
+            "team=platform",
+        ])
+        .unwrap();
+        assert!(matches!(cli.command, Command::Label { .. }));
+    }
+
+    #[test]
+    fn parse_label_artifact_remove() {
+        let cli = parse(&["ak", "label", "artifact", "remove", "abc-123", "env"]).unwrap();
         assert!(matches!(cli.command, Command::Label { .. }));
     }
 

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -1,9 +1,9 @@
-use artifact_keeper_sdk::ClientRepositoryLabelsExt;
+use artifact_keeper_sdk::{ClientArtifactLabelsExt, ClientRepositoryLabelsExt};
 use clap::Subcommand;
 use miette::Result;
 
 use super::client::client_for;
-use super::helpers::{emit_mutation, new_table, sdk_err};
+use super::helpers::{emit_mutation, new_table, parse_uuid, sdk_err};
 use crate::cli::GlobalArgs;
 use crate::error::AkError;
 use crate::output::{self, OutputFormat};
@@ -14,6 +14,12 @@ pub enum LabelCommand {
     Repo {
         #[command(subcommand)]
         command: RepoLabelCommand,
+    },
+
+    /// Manage labels on artifacts
+    Artifact {
+        #[command(subcommand)]
+        command: ArtifactLabelCommand,
     },
 }
 
@@ -44,6 +50,42 @@ pub enum RepoLabelCommand {
     },
 }
 
+#[derive(Subcommand)]
+pub enum ArtifactLabelCommand {
+    /// List labels on an artifact
+    List {
+        /// Artifact ID
+        id: String,
+    },
+
+    /// Add or update a single label on an artifact
+    Add {
+        /// Artifact ID
+        id: String,
+
+        /// Label in key=value format
+        label: String,
+    },
+
+    /// Remove a label from an artifact
+    Remove {
+        /// Artifact ID
+        id: String,
+
+        /// Label key to remove
+        label_key: String,
+    },
+
+    /// Set (replace) all labels on an artifact
+    Set {
+        /// Artifact ID
+        id: String,
+
+        /// Labels in key=value format (value optional); replaces all existing labels
+        labels: Vec<String>,
+    },
+}
+
 impl LabelCommand {
     pub async fn execute(self, global: &GlobalArgs) -> Result<()> {
         match self {
@@ -52,6 +94,18 @@ impl LabelCommand {
                 RepoLabelCommand::Add { key, label } => add_label(&key, &label, global).await,
                 RepoLabelCommand::Remove { key, label_key } => {
                     remove_label(&key, &label_key, global).await
+                }
+            },
+            Self::Artifact { command } => match command {
+                ArtifactLabelCommand::List { id } => list_artifact_labels(&id, global).await,
+                ArtifactLabelCommand::Add { id, label } => {
+                    add_artifact_label(&id, &label, global).await
+                }
+                ArtifactLabelCommand::Remove { id, label_key } => {
+                    remove_artifact_label(&id, &label_key, global).await
+                }
+                ArtifactLabelCommand::Set { id, labels } => {
+                    set_artifact_labels(&id, &labels, global).await
                 }
             },
         }
@@ -193,6 +247,183 @@ async fn remove_label(repo_key: &str, label_key: &str, global: &GlobalArgs) -> R
     Ok(())
 }
 
+// ---- artifact labels ----
+
+async fn list_artifact_labels(id: &str, global: &GlobalArgs) -> Result<()> {
+    let artifact_id = parse_uuid(id, "artifact")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching labels...");
+
+    let resp = client
+        .list_artifact_labels()
+        .id(artifact_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("list artifact labels", e))?;
+
+    spinner.finish_and_clear();
+
+    if resp.items.is_empty() {
+        eprintln!("No labels on artifact '{id}'.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for l in &resp.items {
+            println!("{}={}", l.key, l.value);
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp
+        .items
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "id": l.id.to_string(),
+                "key": l.key,
+                "value": l.value,
+                "created_at": l.created_at.to_rfc3339(),
+            })
+        })
+        .collect();
+
+    let table_str = format_label_table(&entries);
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    Ok(())
+}
+
+async fn add_artifact_label(id: &str, label: &str, global: &GlobalArgs) -> Result<()> {
+    let artifact_id = parse_uuid(id, "artifact")?;
+    let (label_key, label_value) = label
+        .split_once('=')
+        .ok_or_else(|| AkError::ConfigError("Label must be in key=value format".to_string()))?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Adding label...");
+
+    let body = artifact_keeper_sdk::types::AddArtifactLabelRequest {
+        value: Some(label_value.to_string()),
+    };
+
+    client
+        .add_artifact_label()
+        .id(artifact_id)
+        .label_key(label_key)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("add artifact label", e))?;
+
+    spinner.finish_and_clear();
+    emit_mutation(
+        &serde_json::json!({
+            "artifact_id": id,
+            "key": label_key,
+            "value": label_value,
+            "status": "added",
+        }),
+        id,
+        &format!("Label '{label_key}={label_value}' added to artifact '{id}'."),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn remove_artifact_label(id: &str, label_key: &str, global: &GlobalArgs) -> Result<()> {
+    let artifact_id = parse_uuid(id, "artifact")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Removing label...");
+
+    client
+        .delete_artifact_label()
+        .id(artifact_id)
+        .label_key(label_key)
+        .send()
+        .await
+        .map_err(|e| sdk_err("remove artifact label", e))?;
+
+    spinner.finish_and_clear();
+    emit_mutation(
+        &serde_json::json!({
+            "artifact_id": id,
+            "key": label_key,
+            "status": "removed",
+        }),
+        id,
+        &format!("Label '{label_key}' removed from artifact '{id}'."),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn set_artifact_labels(id: &str, labels: &[String], global: &GlobalArgs) -> Result<()> {
+    let artifact_id = parse_uuid(id, "artifact")?;
+
+    let entries: Vec<artifact_keeper_sdk::types::ArtifactLabelEntrySchema> = labels
+        .iter()
+        .map(|l| match l.split_once('=') {
+            Some((k, v)) => artifact_keeper_sdk::types::ArtifactLabelEntrySchema {
+                key: k.to_string(),
+                value: Some(v.to_string()),
+            },
+            None => artifact_keeper_sdk::types::ArtifactLabelEntrySchema {
+                key: l.to_string(),
+                value: None,
+            },
+        })
+        .collect();
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Setting labels...");
+
+    let body = artifact_keeper_sdk::types::SetArtifactLabelsRequest { labels: entries };
+
+    let resp = client
+        .set_artifact_labels()
+        .id(artifact_id)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("set artifact labels", e))?;
+
+    spinner.finish_and_clear();
+
+    let result: Vec<_> = resp
+        .items
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "key": l.key,
+                "value": l.value,
+            })
+        })
+        .collect();
+
+    emit_mutation(
+        &serde_json::json!({
+            "artifact_id": id,
+            "count": resp.items.len(),
+            "labels": result,
+            "status": "set",
+        }),
+        id,
+        &format!("Set {} label(s) on artifact '{id}'.", resp.items.len()),
+        global,
+    );
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -290,6 +521,109 @@ mod tests {
     fn parse_repo_missing_subcommand() {
         let result = try_parse(&["test", "repo"]);
         assert!(result.is_err());
+    }
+
+    // ---- parsing: artifact list ----
+
+    #[test]
+    fn parse_artifact_list() {
+        let cli = parse(&["test", "artifact", "list", "abc-123"]);
+        match cli.command {
+            LabelCommand::Artifact {
+                command: ArtifactLabelCommand::List { id },
+            } => {
+                assert_eq!(id, "abc-123");
+            }
+            _ => panic!("expected Artifact List"),
+        }
+    }
+
+    #[test]
+    fn parse_artifact_list_missing_id() {
+        let result = try_parse(&["test", "artifact", "list"]);
+        assert!(result.is_err());
+    }
+
+    // ---- parsing: artifact add ----
+
+    #[test]
+    fn parse_artifact_add() {
+        let cli = parse(&["test", "artifact", "add", "abc-123", "env=production"]);
+        match cli.command {
+            LabelCommand::Artifact {
+                command: ArtifactLabelCommand::Add { id, label },
+            } => {
+                assert_eq!(id, "abc-123");
+                assert_eq!(label, "env=production");
+            }
+            _ => panic!("expected Artifact Add"),
+        }
+    }
+
+    #[test]
+    fn parse_artifact_add_missing_label() {
+        let result = try_parse(&["test", "artifact", "add", "abc-123"]);
+        assert!(result.is_err());
+    }
+
+    // ---- parsing: artifact remove ----
+
+    #[test]
+    fn parse_artifact_remove() {
+        let cli = parse(&["test", "artifact", "remove", "abc-123", "env"]);
+        match cli.command {
+            LabelCommand::Artifact {
+                command: ArtifactLabelCommand::Remove { id, label_key },
+            } => {
+                assert_eq!(id, "abc-123");
+                assert_eq!(label_key, "env");
+            }
+            _ => panic!("expected Artifact Remove"),
+        }
+    }
+
+    #[test]
+    fn parse_artifact_remove_missing_label_key() {
+        let result = try_parse(&["test", "artifact", "remove", "abc-123"]);
+        assert!(result.is_err());
+    }
+
+    // ---- parsing: artifact set ----
+
+    #[test]
+    fn parse_artifact_set() {
+        let cli = parse(&[
+            "test",
+            "artifact",
+            "set",
+            "abc-123",
+            "env=production",
+            "team=platform",
+        ]);
+        match cli.command {
+            LabelCommand::Artifact {
+                command: ArtifactLabelCommand::Set { id, labels },
+            } => {
+                assert_eq!(id, "abc-123");
+                assert_eq!(labels, vec!["env=production", "team=platform"]);
+            }
+            _ => panic!("expected Artifact Set"),
+        }
+    }
+
+    #[test]
+    fn parse_artifact_set_empty_labels() {
+        // `set` with zero labels is allowed (clears all labels)
+        let cli = parse(&["test", "artifact", "set", "abc-123"]);
+        match cli.command {
+            LabelCommand::Artifact {
+                command: ArtifactLabelCommand::Set { id, labels },
+            } => {
+                assert_eq!(id, "abc-123");
+                assert!(labels.is_empty());
+            }
+            _ => panic!("expected Artifact Set"),
+        }
     }
 
     // ---- format functions ----
@@ -470,6 +804,141 @@ mod tests {
         let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
         let result = remove_label("npm-local", "env", &global).await;
         assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    // ---- wiremock handler tests: artifact labels ----
+
+    const TEST_ARTIFACT_ID: &str = "00000000-0000-0000-0000-000000000002";
+
+    fn artifact_label_json() -> serde_json::Value {
+        json!({
+            "id": "00000000-0000-0000-0000-000000000001",
+            "artifact_id": TEST_ARTIFACT_ID,
+            "key": "env",
+            "value": "production",
+            "created_at": "2026-01-15T12:00:00Z"
+        })
+    }
+
+    #[tokio::test]
+    async fn handler_list_artifact_labels_empty() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path(format!("/api/v1/artifacts/{TEST_ARTIFACT_ID}/labels")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "items": [],
+                "total": 0_u64
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = list_artifact_labels(TEST_ARTIFACT_ID, &global).await;
+        assert!(result.is_ok(), "list failed: {:?}", result.err());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_list_artifact_labels_with_data() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path(format!("/api/v1/artifacts/{TEST_ARTIFACT_ID}/labels")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "items": [artifact_label_json()],
+                "total": 1_u64
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Table);
+        let result = list_artifact_labels(TEST_ARTIFACT_ID, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_list_artifact_labels_invalid_id() {
+        let (_server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = list_artifact_labels("not-a-uuid", &global).await;
+        assert!(result.is_err());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_add_artifact_label() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/api/v1/artifacts/{TEST_ARTIFACT_ID}/labels/env"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(artifact_label_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = add_artifact_label(TEST_ARTIFACT_ID, "env=production", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_add_artifact_label_invalid_format() {
+        let (_server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = add_artifact_label(TEST_ARTIFACT_ID, "no-equals-sign", &global).await;
+        assert!(result.is_err());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_remove_artifact_label() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("DELETE"))
+            .and(path(format!(
+                "/api/v1/artifacts/{TEST_ARTIFACT_ID}/labels/env"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = remove_artifact_label(TEST_ARTIFACT_ID, "env", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_set_artifact_labels() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path(format!("/api/v1/artifacts/{TEST_ARTIFACT_ID}/labels")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "items": [artifact_label_json()],
+                "total": 1_u64
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let labels = vec!["env=production".to_string(), "team".to_string()];
+        let result = set_artifact_labels(TEST_ARTIFACT_ID, &labels, &global).await;
+        assert!(result.is_ok(), "set failed: {:?}", result.err());
         crate::test_utils::teardown_env();
     }
 


### PR DESCRIPTION
## Summary

Extends the existing `ak label` command group with an `artifact` subgroup, wiring the four artifact-label SDK operations that were previously not exposed by the CLI. Repository labels (`ak label repo ...`) were already covered; artifact labels (labels *on* artifacts, `/artifacts/{id}/labels`) were not.

| SDK op | Endpoint | Command |
| --- | --- | --- |
| `list_artifact_labels` | `GET /api/v1/artifacts/{id}/labels` | `ak label artifact list <id>` |
| `add_artifact_label` | `POST /api/v1/artifacts/{id}/labels/{key}` | `ak label artifact add <id> key=value` |
| `set_artifact_labels` | `PUT /api/v1/artifacts/{id}/labels` | `ak label artifact set <id> k1=v1 k2=v2 ...` |
| `delete_artifact_label` | `DELETE /api/v1/artifacts/{id}/labels/{key}` | `ak label artifact remove <id> key` |

`set` replaces all labels on the artifact in a single call and accepts repeated `key=value` positional arguments (value optional). Output honors the existing `table`/`json`/`yaml`/`quiet` conventions and the shared mutation emitter, matching the repository-label commands.

Chose to extend `label.rs`/`LabelCommand` rather than add a new top-level group, since the artifact labels are the same conceptual domain as the already-present repository labels.

## Test Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings -A dead_code`
- [x] `cargo build` / `cargo build --release`
- [x] `cargo test --workspace` (1545 unit tests pass; 17 new label tests)
- [x] Manual smoke test against a live backend: add / list (table, json, quiet) / set (replace-all) / remove, plus invalid-UUID and invalid-format error paths. Test artifact and labels cleaned up afterward.

## API Changes

None (CLI-only; consumes existing v1.4.0 SDK operations).

## Notes

While smoke-testing, `ak artifact push` reported a live upload as an error even though the object was created (HTTP 201) — this is the known success-status drift tracked in #98 and is unrelated to this change.
