### PR TITLE
feat(repo): wire the unwired repositories operations

### DIFF
--- a/src/commands/repo.rs
+++ b/src/commands/repo.rs
@@ -1,10 +1,11 @@
 use artifact_keeper_sdk::ClientRepositoriesExt;
 use clap::Subcommand;
 use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
+use futures::StreamExt;
 use miette::{IntoDiagnostic, Result};
 
 use super::client::{client_for, client_for_optional_auth};
-use super::helpers::emit_mutation;
+use super::helpers::{confirm_action, emit_mutation, new_table, sdk_err};
 use crate::cli::GlobalArgs;
 use crate::error::AkError;
 use crate::output::{self, OutputFormat, format_bytes};
@@ -81,6 +82,267 @@ pub enum RepoCommand {
         /// Repository key
         key: String,
     },
+
+    /// Update repository settings (partial; only provided fields are changed)
+    Update {
+        /// Repository key
+        key: String,
+
+        /// New repository key (rename the URL slug)
+        #[arg(long = "new-key")]
+        new_key: Option<String>,
+
+        /// Display name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Public visibility (true/false)
+        #[arg(long)]
+        public: Option<bool>,
+
+        /// Allow anonymous (unauthenticated) downloads (true/false)
+        #[arg(long = "allow-anonymous")]
+        allow_anonymous: Option<bool>,
+
+        /// Restrict this repository to receive artifacts via promotion only (true/false)
+        #[arg(long = "promotion-only")]
+        promotion_only: Option<bool>,
+
+        /// Storage quota in bytes (0 or negative clears the quota server-side)
+        #[arg(long = "quota-bytes")]
+        quota_bytes: Option<i64>,
+
+        /// Hold newly uploaded artifacts until scanned (true/false)
+        #[arg(long = "quarantine-enabled")]
+        quarantine_enabled: Option<bool>,
+
+        /// Quarantine hold duration in minutes
+        #[arg(long = "quarantine-duration-minutes")]
+        quarantine_duration_minutes: Option<i64>,
+
+        /// Cargo index upstream URL (remote repos)
+        #[arg(long = "index-upstream-url")]
+        index_upstream_url: Option<String>,
+
+        /// PyPI simple-index prefix ("" for flat CDN, "simple" for PEP 503 default)
+        #[arg(long = "pypi-upstream-index-path")]
+        pypi_upstream_index_path: Option<String>,
+
+        /// Link this staging repo to a release repo by key ("" removes the link)
+        #[arg(long = "release-repository-key")]
+        release_repository_key: Option<String>,
+    },
+
+    /// Manage virtual-repository members
+    Members {
+        #[command(subcommand)]
+        command: MembersCommand,
+    },
+
+    /// Manage remote-repository routing rules (path rewrites)
+    RoutingRules {
+        #[command(subcommand)]
+        command: RoutingRulesCommand,
+    },
+
+    /// Manage the proxy cache of a remote repository
+    Cache {
+        #[command(subcommand)]
+        command: CacheCommand,
+    },
+
+    /// Manage PEP 708 PyPI `tracks` declarations
+    PypiTracks {
+        #[command(subcommand)]
+        command: PypiTracksCommand,
+    },
+
+    /// Set or remove upstream auth for a remote repository
+    UpstreamAuth {
+        /// Repository key
+        key: String,
+
+        /// Auth type: basic, bearer, or none (removes stored auth)
+        #[arg(long = "type", name = "type")]
+        auth_type: String,
+
+        /// Username (basic auth)
+        #[arg(long)]
+        username: Option<String>,
+
+        /// Password (basic) or token (bearer); prompted if omitted for basic/bearer
+        #[arg(long)]
+        password: Option<String>,
+    },
+
+    /// Test connectivity to a remote repository's upstream URL
+    TestUpstream {
+        /// Repository key
+        key: String,
+    },
+
+    /// Browse the artifact tree of a repository
+    Tree {
+        /// Repository key
+        key: String,
+
+        /// Path prefix to browse within the repository
+        #[arg(long)]
+        path: Option<String>,
+
+        /// Include per-node metadata (size, timestamps)
+        #[arg(long)]
+        metadata: bool,
+    },
+
+    /// Print the raw content of an artifact by path
+    Cat {
+        /// Repository key
+        key: String,
+
+        /// Full artifact path within the repository
+        path: String,
+
+        /// Maximum number of bytes to fetch (truncates the response)
+        #[arg(long = "max-bytes")]
+        max_bytes: Option<i64>,
+    },
+}
+
+/// Virtual-repository member management.
+#[derive(Subcommand)]
+pub enum MembersCommand {
+    /// List members of a virtual repository
+    List {
+        /// Repository key
+        key: String,
+    },
+
+    /// Add a member repository to a virtual repository
+    Add {
+        /// Virtual repository key
+        key: String,
+
+        /// Member repository key to add
+        member_key: String,
+
+        /// Resolution priority (lower wins first)
+        #[arg(long)]
+        priority: Option<i32>,
+    },
+
+    /// Remove a member repository from a virtual repository
+    Remove {
+        /// Virtual repository key
+        key: String,
+
+        /// Member repository key to remove
+        member_key: String,
+    },
+
+    /// Reorder all members by priority (bulk). Each entry is `member_key=priority`.
+    Reorder {
+        /// Virtual repository key
+        key: String,
+
+        /// Member priorities as `member_key=priority` (repeatable)
+        #[arg(required = true)]
+        members: Vec<String>,
+    },
+}
+
+/// Remote-repository routing-rule management.
+#[derive(Subcommand)]
+pub enum RoutingRulesCommand {
+    /// Show the routing rules for a repository
+    Get {
+        /// Repository key
+        key: String,
+    },
+
+    /// Replace the routing rules for a repository. Each rule is `pattern=>rewrite`.
+    Set {
+        /// Repository key
+        key: String,
+
+        /// Routing rule as `<regex-pattern>=><rewrite-template>` (repeatable)
+        #[arg(long = "rule", required = true)]
+        rules: Vec<String>,
+    },
+
+    /// Delete all routing rules for a repository
+    Delete {
+        /// Repository key
+        key: String,
+
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+/// Proxy-cache management for remote repositories.
+#[derive(Subcommand)]
+pub enum CacheCommand {
+    /// Show the proxy cache TTL for a repository
+    GetTtl {
+        /// Repository key
+        key: String,
+    },
+
+    /// Set the proxy cache TTL (in seconds) for a repository
+    SetTtl {
+        /// Repository key
+        key: String,
+
+        /// Cache TTL in seconds
+        seconds: i64,
+    },
+
+    /// Invalidate a single cached artifact entry
+    Invalidate {
+        /// Repository key
+        key: String,
+
+        /// Artifact path to evict from the proxy cache
+        path: String,
+    },
+}
+
+/// PEP 708 PyPI `tracks` declaration management.
+#[derive(Subcommand)]
+pub enum PypiTracksCommand {
+    /// List `tracks` declarations on a repository
+    List {
+        /// Repository key
+        key: String,
+    },
+
+    /// Declare (upsert) that a local project tracks an upstream one
+    Set {
+        /// Repository key
+        key: String,
+
+        /// Local project name (PEP 503 normalized server-side)
+        project: String,
+
+        /// Upstream Simple index project URL this project tracks
+        #[arg(long = "tracks-url")]
+        tracks_url: String,
+    },
+
+    /// Remove a `tracks` declaration, restoring local-precedence isolation
+    Remove {
+        /// Repository key
+        key: String,
+
+        /// Local project name (PEP 503 normalized server-side)
+        project: String,
+    },
 }
 
 impl RepoCommand {
@@ -125,6 +387,99 @@ impl RepoCommand {
             }
             Self::Delete { key, yes } => delete_repo(&key, yes, global).await,
             Self::Browse { key } => browse_repo(&key, global).await,
+            Self::Update {
+                key,
+                new_key,
+                name,
+                description,
+                public,
+                allow_anonymous,
+                promotion_only,
+                quota_bytes,
+                quarantine_enabled,
+                quarantine_duration_minutes,
+                index_upstream_url,
+                pypi_upstream_index_path,
+                release_repository_key,
+            } => {
+                update_repo(
+                    &key,
+                    artifact_keeper_sdk::types::UpdateRepositoryRequest {
+                        key: new_key,
+                        name,
+                        description,
+                        is_public: public,
+                        allow_anonymous_access: allow_anonymous,
+                        promotion_only,
+                        quota_bytes,
+                        quarantine_enabled,
+                        quarantine_duration_minutes,
+                        index_upstream_url,
+                        pypi_upstream_index_path,
+                        release_repository_key,
+                    },
+                    global,
+                )
+                .await
+            }
+            Self::Members { command } => match command {
+                MembersCommand::List { key } => list_members(&key, global).await,
+                MembersCommand::Add {
+                    key,
+                    member_key,
+                    priority,
+                } => add_member(&key, &member_key, priority, global).await,
+                MembersCommand::Remove { key, member_key } => {
+                    remove_member(&key, &member_key, global).await
+                }
+                MembersCommand::Reorder { key, members } => {
+                    reorder_members(&key, &members, global).await
+                }
+            },
+            Self::RoutingRules { command } => match command {
+                RoutingRulesCommand::Get { key } => get_routing_rules(&key, global).await,
+                RoutingRulesCommand::Set { key, rules } => {
+                    set_routing_rules(&key, &rules, global).await
+                }
+                RoutingRulesCommand::Delete { key, yes } => {
+                    delete_routing_rules(&key, yes, global).await
+                }
+            },
+            Self::Cache { command } => match command {
+                CacheCommand::GetTtl { key } => get_cache_ttl(&key, global).await,
+                CacheCommand::SetTtl { key, seconds } => set_cache_ttl(&key, seconds, global).await,
+                CacheCommand::Invalidate { key, path } => {
+                    invalidate_cache(&key, &path, global).await
+                }
+            },
+            Self::PypiTracks { command } => match command {
+                PypiTracksCommand::List { key } => list_pypi_tracks(&key, global).await,
+                PypiTracksCommand::Set {
+                    key,
+                    project,
+                    tracks_url,
+                } => put_pypi_track(&key, &project, &tracks_url, global).await,
+                PypiTracksCommand::Remove { key, project } => {
+                    delete_pypi_track(&key, &project, global).await
+                }
+            },
+            Self::UpstreamAuth {
+                key,
+                auth_type,
+                username,
+                password,
+            } => set_upstream_auth(&key, &auth_type, username, password, global).await,
+            Self::TestUpstream { key } => test_upstream(&key, global).await,
+            Self::Tree {
+                key,
+                path,
+                metadata,
+            } => browse_tree(&key, path.as_deref(), metadata, global).await,
+            Self::Cat {
+                key,
+                path,
+                max_bytes,
+            } => cat_content(&key, &path, max_bytes, global).await,
         }
     }
 }
@@ -418,6 +773,703 @@ async fn browse_repo(key: &str, global: &GlobalArgs) -> Result<()> {
     Ok(())
 }
 
+async fn update_repo(
+    key: &str,
+    body: artifact_keeper_sdk::types::UpdateRepositoryRequest,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Updating repository...");
+
+    let resp = client
+        .update_repository()
+        .key(key)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("update repository", e))?;
+
+    spinner.finish_and_clear();
+
+    let info = serde_json::json!({
+        "key": resp.key,
+        "name": resp.name,
+        "format": resp.format,
+        "type": resp.repo_type,
+        "public": resp.is_public,
+        "allow_anonymous_access": resp.allow_anonymous_access,
+        "promotion_only": resp.promotion_only,
+        "description": resp.description,
+        "quota_bytes": resp.quota_bytes,
+        "quarantine_enabled": resp.quarantine_enabled,
+        "quarantine_duration_minutes": resp.quarantine_duration_minutes,
+        "upstream_url": resp.upstream_url,
+    });
+
+    emit_mutation(
+        &info,
+        &resp.key,
+        &format!("Updated repository '{}'.", resp.key),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn list_members(key: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching members...");
+
+    let resp = client
+        .list_virtual_members()
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| sdk_err("list virtual members", e))?;
+
+    spinner.finish_and_clear();
+
+    if resp.members.is_empty() {
+        eprintln!("No members on virtual repository '{key}'.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for m in &resp.members {
+            println!("{}", m.member_repo_key);
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp
+        .members
+        .iter()
+        .map(|m| {
+            serde_json::json!({
+                "member_key": m.member_repo_key,
+                "name": m.member_repo_name,
+                "type": m.member_repo_type,
+                "priority": m.priority,
+            })
+        })
+        .collect();
+
+    let table_str = {
+        let mut table = new_table(vec!["MEMBER KEY", "NAME", "TYPE", "PRIORITY"]);
+        for m in &resp.members {
+            let priority = m.priority.to_string();
+            table.add_row(vec![
+                m.member_repo_key.as_str(),
+                m.member_repo_name.as_str(),
+                m.member_repo_type.as_str(),
+                priority.as_str(),
+            ]);
+        }
+        table.to_string()
+    };
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    Ok(())
+}
+
+async fn add_member(
+    key: &str,
+    member_key: &str,
+    priority: Option<i32>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Adding member...");
+
+    let body = artifact_keeper_sdk::types::AddVirtualMemberRequest {
+        member_key: member_key.to_string(),
+        priority,
+    };
+
+    let resp = client
+        .add_virtual_member()
+        .key(key)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("add virtual member", e))?;
+
+    spinner.finish_and_clear();
+
+    emit_mutation(
+        &*resp,
+        &resp.member_repo_key,
+        &format!(
+            "Added '{}' to virtual repository '{key}'.",
+            resp.member_repo_key
+        ),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn remove_member(key: &str, member_key: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    client
+        .remove_virtual_member()
+        .key(key)
+        .member_key(member_key)
+        .send()
+        .await
+        .map_err(|e| sdk_err("remove virtual member", e))?;
+
+    emit_mutation(
+        &serde_json::json!({ "member_key": member_key, "status": "removed" }),
+        member_key,
+        &format!("Removed '{member_key}' from virtual repository '{key}'."),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn reorder_members(key: &str, members: &[String], global: &GlobalArgs) -> Result<()> {
+    let mut priorities = Vec::with_capacity(members.len());
+    for entry in members {
+        let (member_key, priority) = entry.split_once('=').ok_or_else(|| {
+            AkError::ConfigError(format!(
+                "Member priority must be in 'member_key=priority' format: {entry}"
+            ))
+        })?;
+        let priority: i32 = priority.parse().map_err(|_| {
+            AkError::ConfigError(format!("Invalid priority '{priority}' in entry '{entry}'"))
+        })?;
+        priorities.push(artifact_keeper_sdk::types::VirtualMemberPriority {
+            member_key: member_key.to_string(),
+            priority,
+        });
+    }
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Reordering members...");
+
+    let resp = client
+        .update_virtual_members()
+        .key(key)
+        .body(artifact_keeper_sdk::types::UpdateVirtualMembersRequest {
+            members: priorities,
+        })
+        .send()
+        .await
+        .map_err(|e| sdk_err("reorder virtual members", e))?;
+
+    spinner.finish_and_clear();
+
+    let info = serde_json::json!({
+        "members": resp.members.iter().map(|m| serde_json::json!({
+            "member_key": m.member_repo_key,
+            "priority": m.priority,
+        })).collect::<Vec<_>>(),
+    });
+
+    emit_mutation(
+        &info,
+        key,
+        &format!("Reordered {} member(s) on '{key}'.", resp.members.len()),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn get_routing_rules(key: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching routing rules...");
+
+    let resp = client
+        .get_routing_rules()
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get routing rules", e))?;
+
+    spinner.finish_and_clear();
+
+    if resp.rules.is_empty() {
+        eprintln!("No routing rules on repository '{key}'.");
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp
+        .rules
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "path_pattern": r.path_pattern,
+                "rewrite_to": r.rewrite_to,
+            })
+        })
+        .collect();
+
+    let table_str = {
+        let mut table = new_table(vec!["PATTERN", "REWRITE TO"]);
+        for r in &resp.rules {
+            table.add_row(vec![r.path_pattern.as_str(), r.rewrite_to.as_str()]);
+        }
+        table.to_string()
+    };
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    Ok(())
+}
+
+async fn set_routing_rules(key: &str, rules: &[String], global: &GlobalArgs) -> Result<()> {
+    let mut parsed = Vec::with_capacity(rules.len());
+    for rule in rules {
+        let (pattern, rewrite) = rule.split_once("=>").ok_or_else(|| {
+            AkError::ConfigError(format!(
+                "Routing rule must be in '<pattern>=><rewrite>' format: {rule}"
+            ))
+        })?;
+        parsed.push(artifact_keeper_sdk::types::RoutingRule {
+            path_pattern: pattern.trim().to_string(),
+            rewrite_to: rewrite.trim().to_string(),
+        });
+    }
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Setting routing rules...");
+
+    let resp = client
+        .set_routing_rules()
+        .key(key)
+        .body(artifact_keeper_sdk::types::SetRoutingRulesRequest { rules: parsed })
+        .send()
+        .await
+        .map_err(|e| sdk_err("set routing rules", e))?;
+
+    spinner.finish_and_clear();
+
+    let info = serde_json::json!({
+        "repository_key": resp.repository_key,
+        "rules": resp.rules.iter().map(|r| serde_json::json!({
+            "path_pattern": r.path_pattern,
+            "rewrite_to": r.rewrite_to,
+        })).collect::<Vec<_>>(),
+    });
+
+    emit_mutation(
+        &info,
+        &resp.repository_key,
+        &format!("Set {} routing rule(s) on '{key}'.", resp.rules.len()),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn delete_routing_rules(key: &str, skip_confirm: bool, global: &GlobalArgs) -> Result<()> {
+    if !confirm_action(
+        &format!("Delete all routing rules for '{key}'?"),
+        skip_confirm,
+        global.no_input,
+    )? {
+        return Ok(());
+    }
+
+    let client = client_for(global)?;
+
+    client
+        .delete_routing_rules()
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| sdk_err("delete routing rules", e))?;
+
+    emit_mutation(
+        &serde_json::json!({ "key": key, "status": "deleted" }),
+        key,
+        &format!("Deleted routing rules for '{key}'."),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn get_cache_ttl(key: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    let resp = client
+        .get_cache_ttl()
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get cache TTL", e))?;
+
+    let info = serde_json::json!({
+        "repository_key": resp.repository_key,
+        "cache_ttl_seconds": resp.cache_ttl_seconds,
+    });
+
+    let table_str = format!(
+        "Repository:  {}\nCache TTL:   {} seconds",
+        resp.repository_key, resp.cache_ttl_seconds
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn set_cache_ttl(key: &str, seconds: i64, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    let resp = client
+        .set_cache_ttl()
+        .key(key)
+        .body(artifact_keeper_sdk::types::SetCacheTtlRequest {
+            cache_ttl_seconds: seconds,
+        })
+        .send()
+        .await
+        .map_err(|e| sdk_err("set cache TTL", e))?;
+
+    let info = serde_json::json!({
+        "repository_key": resp.repository_key,
+        "cache_ttl_seconds": resp.cache_ttl_seconds,
+    });
+
+    emit_mutation(
+        &info,
+        &resp.repository_key,
+        &format!(
+            "Set cache TTL for '{}' to {} seconds.",
+            resp.repository_key, resp.cache_ttl_seconds
+        ),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn invalidate_cache(key: &str, path: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    let resp = client
+        .invalidate_cache()
+        .key(key)
+        .path(path)
+        .send()
+        .await
+        .map_err(|e| sdk_err("invalidate cache", e))?;
+
+    let info = serde_json::json!({
+        "repository_key": resp.repository_key,
+        "path": resp.path,
+        "invalidated": resp.invalidated,
+    });
+
+    emit_mutation(
+        &info,
+        &resp.path,
+        &format!(
+            "Invalidated cache entry '{}' on '{}' (invalidated: {}).",
+            resp.path, resp.repository_key, resp.invalidated
+        ),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn list_pypi_tracks(key: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching PyPI tracks...");
+
+    let resp = client
+        .list_pypi_tracks()
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| sdk_err("list PyPI tracks", e))?;
+
+    spinner.finish_and_clear();
+
+    if resp.items.is_empty() {
+        eprintln!("No PyPI tracks declared on repository '{key}'.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for t in &resp.items {
+            println!("{}", t.normalized_name);
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp
+        .items
+        .iter()
+        .map(|t| {
+            serde_json::json!({
+                "normalized_name": t.normalized_name,
+                "tracks_url": t.tracks_url,
+                "repository_key": t.repository_key,
+            })
+        })
+        .collect();
+
+    let table_str = {
+        let mut table = new_table(vec!["PROJECT", "TRACKS URL"]);
+        for t in &resp.items {
+            table.add_row(vec![t.normalized_name.as_str(), t.tracks_url.as_str()]);
+        }
+        table.to_string()
+    };
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    Ok(())
+}
+
+async fn put_pypi_track(
+    key: &str,
+    project: &str,
+    tracks_url: &str,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for(global)?;
+
+    let resp = client
+        .put_pypi_track()
+        .key(key)
+        .project(project)
+        .body(artifact_keeper_sdk::types::PypiTrackRequest {
+            tracks_url: tracks_url.to_string(),
+        })
+        .send()
+        .await
+        .map_err(|e| sdk_err("set PyPI track", e))?;
+
+    let info = serde_json::json!({
+        "normalized_name": resp.normalized_name,
+        "tracks_url": resp.tracks_url,
+        "repository_key": resp.repository_key,
+    });
+
+    emit_mutation(
+        &info,
+        &resp.normalized_name,
+        &format!(
+            "Declared track '{}' -> {} on '{key}'.",
+            resp.normalized_name, resp.tracks_url
+        ),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn delete_pypi_track(key: &str, project: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    client
+        .delete_pypi_track()
+        .key(key)
+        .project(project)
+        .send()
+        .await
+        .map_err(|e| sdk_err("remove PyPI track", e))?;
+
+    emit_mutation(
+        &serde_json::json!({ "project": project, "status": "removed" }),
+        project,
+        &format!("Removed PyPI track '{project}' from '{key}'."),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn set_upstream_auth(
+    key: &str,
+    auth_type: &str,
+    username: Option<String>,
+    password: Option<String>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    // Prompt for the secret when setting basic/bearer auth and none was provided.
+    let password = match password {
+        Some(p) => Some(p),
+        None if matches!(auth_type, "basic" | "bearer") && !global.no_input => Some(
+            dialoguer::Password::new()
+                .with_prompt("Upstream password/token")
+                .interact()
+                .into_diagnostic()?,
+        ),
+        None => None,
+    };
+
+    let client = client_for(global)?;
+
+    client
+        .set_upstream_auth()
+        .key(key)
+        .body(artifact_keeper_sdk::types::UpstreamAuthRequest {
+            auth_type: auth_type.to_string(),
+            username,
+            password,
+        })
+        .send()
+        .await
+        .map_err(|e| sdk_err("set upstream auth", e))?;
+
+    let action = if auth_type == "none" {
+        format!("Removed upstream auth from '{key}'.")
+    } else {
+        format!("Set upstream auth ({auth_type}) on '{key}'.")
+    };
+
+    emit_mutation(
+        &serde_json::json!({ "key": key, "auth_type": auth_type }),
+        key,
+        &action,
+        global,
+    );
+
+    Ok(())
+}
+
+async fn test_upstream(key: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Testing upstream connectivity...");
+
+    client
+        .test_upstream()
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| sdk_err("test upstream", e))?;
+
+    spinner.finish_and_clear();
+
+    emit_mutation(
+        &serde_json::json!({ "key": key, "upstream": "reachable" }),
+        key,
+        &format!("Upstream for '{key}' is reachable."),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn browse_tree(
+    key: &str,
+    path: Option<&str>,
+    metadata: bool,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for_optional_auth(global)?;
+    let spinner = output::spinner("Loading tree...");
+
+    let mut req = client.get_tree().repository_key(key);
+    if let Some(p) = path {
+        req = req.path(p);
+    }
+    if metadata {
+        req = req.include_metadata(true);
+    }
+
+    let resp = req.send().await.map_err(|e| sdk_err("browse tree", e))?;
+
+    spinner.finish_and_clear();
+
+    if resp.nodes.is_empty() {
+        eprintln!("No nodes under '{key}'.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for n in &resp.nodes {
+            println!("{}", n.path);
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp
+        .nodes
+        .iter()
+        .map(|n| {
+            serde_json::json!({
+                "name": n.name,
+                "path": n.path,
+                "type": n.type_,
+                "has_children": n.has_children,
+                "size_bytes": n.size_bytes,
+            })
+        })
+        .collect();
+
+    let table_str = {
+        let mut table = new_table(vec!["NAME", "TYPE", "PATH", "SIZE"]);
+        for n in &resp.nodes {
+            let size = n.size_bytes.map(format_bytes).unwrap_or_else(|| "-".into());
+            table.add_row(vec![
+                n.name.as_str(),
+                n.type_.as_str(),
+                n.path.as_str(),
+                size.as_str(),
+            ]);
+        }
+        table.to_string()
+    };
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    Ok(())
+}
+
+async fn cat_content(
+    key: &str,
+    path: &str,
+    max_bytes: Option<i64>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for_optional_auth(global)?;
+
+    let mut req = client.get_content().repository_key(key).path(path);
+    if let Some(mb) = max_bytes {
+        req = req.max_bytes(mb);
+    }
+
+    let resp = req.send().await.map_err(|e| sdk_err("get content", e))?;
+
+    let mut stream = resp.into_inner();
+    let mut stdout = tokio::io::stdout();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| sdk_err("read content", e))?;
+        tokio::io::AsyncWriteExt::write_all(&mut stdout, &chunk)
+            .await
+            .into_diagnostic()?;
+    }
+    tokio::io::AsyncWriteExt::flush(&mut stdout)
+        .await
+        .into_diagnostic()?;
+
+    Ok(())
+}
+
 /// Format a list of repository entries as a table string.
 fn format_repos_table(items: &[serde_json::Value]) -> String {
     let mut table = Table::new();
@@ -703,6 +1755,277 @@ mod tests {
     #[test]
     fn parse_browse_missing_key_fails() {
         assert!(try_parse(&["test", "browse"]).is_err());
+    }
+
+    // ---- Update subcommand parsing ----
+
+    #[test]
+    fn parse_update_partial() {
+        let cli = parse(&["test", "update", "my-repo", "--description", "hi"]);
+        if let RepoCommand::Update {
+            key,
+            name,
+            description,
+            public,
+            ..
+        } = cli.command
+        {
+            assert_eq!(key, "my-repo");
+            assert!(name.is_none());
+            assert_eq!(description.as_deref(), Some("hi"));
+            assert!(public.is_none());
+        } else {
+            panic!("Expected RepoCommand::Update");
+        }
+    }
+
+    #[test]
+    fn parse_update_bool_and_numeric_flags() {
+        let cli = parse(&[
+            "test",
+            "update",
+            "r",
+            "--public",
+            "true",
+            "--promotion-only",
+            "false",
+            "--quota-bytes",
+            "1048576",
+            "--new-key",
+            "renamed",
+        ]);
+        if let RepoCommand::Update {
+            new_key,
+            public,
+            promotion_only,
+            quota_bytes,
+            ..
+        } = cli.command
+        {
+            assert_eq!(new_key.as_deref(), Some("renamed"));
+            assert_eq!(public, Some(true));
+            assert_eq!(promotion_only, Some(false));
+            assert_eq!(quota_bytes, Some(1048576));
+        } else {
+            panic!("Expected RepoCommand::Update");
+        }
+    }
+
+    #[test]
+    fn parse_update_missing_key_fails() {
+        assert!(try_parse(&["test", "update"]).is_err());
+    }
+
+    // ---- Members subcommand parsing ----
+
+    #[test]
+    fn parse_members_list() {
+        let cli = parse(&["test", "members", "list", "virt"]);
+        assert!(matches!(
+            cli.command,
+            RepoCommand::Members {
+                command: MembersCommand::List { .. }
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_members_add_with_priority() {
+        let cli = parse(&["test", "members", "add", "virt", "mem", "--priority", "5"]);
+        if let RepoCommand::Members {
+            command:
+                MembersCommand::Add {
+                    key,
+                    member_key,
+                    priority,
+                },
+        } = cli.command
+        {
+            assert_eq!(key, "virt");
+            assert_eq!(member_key, "mem");
+            assert_eq!(priority, Some(5));
+        } else {
+            panic!("Expected MembersCommand::Add");
+        }
+    }
+
+    #[test]
+    fn parse_members_reorder_variadic() {
+        let cli = parse(&["test", "members", "reorder", "virt", "a=1", "b=2"]);
+        if let RepoCommand::Members {
+            command: MembersCommand::Reorder { key, members },
+        } = cli.command
+        {
+            assert_eq!(key, "virt");
+            assert_eq!(members, vec!["a=1".to_string(), "b=2".to_string()]);
+        } else {
+            panic!("Expected MembersCommand::Reorder");
+        }
+    }
+
+    #[test]
+    fn parse_members_reorder_requires_entries() {
+        assert!(try_parse(&["test", "members", "reorder", "virt"]).is_err());
+    }
+
+    // ---- Routing-rules subcommand parsing ----
+
+    #[test]
+    fn parse_routing_rules_set() {
+        let cli = parse(&["test", "routing-rules", "set", "r", "--rule", "a=>b"]);
+        if let RepoCommand::RoutingRules {
+            command: RoutingRulesCommand::Set { key, rules },
+        } = cli.command
+        {
+            assert_eq!(key, "r");
+            assert_eq!(rules, vec!["a=>b".to_string()]);
+        } else {
+            panic!("Expected RoutingRulesCommand::Set");
+        }
+    }
+
+    #[test]
+    fn parse_routing_rules_get() {
+        let cli = parse(&["test", "routing-rules", "get", "r"]);
+        assert!(matches!(
+            cli.command,
+            RepoCommand::RoutingRules {
+                command: RoutingRulesCommand::Get { .. }
+            }
+        ));
+    }
+
+    // ---- Cache subcommand parsing ----
+
+    #[test]
+    fn parse_cache_set_ttl() {
+        let cli = parse(&["test", "cache", "set-ttl", "r", "3600"]);
+        if let RepoCommand::Cache {
+            command: CacheCommand::SetTtl { key, seconds },
+        } = cli.command
+        {
+            assert_eq!(key, "r");
+            assert_eq!(seconds, 3600);
+        } else {
+            panic!("Expected CacheCommand::SetTtl");
+        }
+    }
+
+    #[test]
+    fn parse_cache_invalidate() {
+        let cli = parse(&["test", "cache", "invalidate", "r", "some/path.tgz"]);
+        if let RepoCommand::Cache {
+            command: CacheCommand::Invalidate { key, path },
+        } = cli.command
+        {
+            assert_eq!(key, "r");
+            assert_eq!(path, "some/path.tgz");
+        } else {
+            panic!("Expected CacheCommand::Invalidate");
+        }
+    }
+
+    // ---- PyPI tracks subcommand parsing ----
+
+    #[test]
+    fn parse_pypi_tracks_set() {
+        let cli = parse(&[
+            "test",
+            "pypi-tracks",
+            "set",
+            "r",
+            "acme",
+            "--tracks-url",
+            "https://pypi.org/simple/acme/",
+        ]);
+        if let RepoCommand::PypiTracks {
+            command:
+                PypiTracksCommand::Set {
+                    key,
+                    project,
+                    tracks_url,
+                },
+        } = cli.command
+        {
+            assert_eq!(key, "r");
+            assert_eq!(project, "acme");
+            assert_eq!(tracks_url, "https://pypi.org/simple/acme/");
+        } else {
+            panic!("Expected PypiTracksCommand::Set");
+        }
+    }
+
+    // ---- Upstream-auth / test-upstream parsing ----
+
+    #[test]
+    fn parse_upstream_auth() {
+        let cli = parse(&[
+            "test",
+            "upstream-auth",
+            "r",
+            "--type",
+            "basic",
+            "--username",
+            "u",
+            "--password",
+            "p",
+        ]);
+        if let RepoCommand::UpstreamAuth {
+            key,
+            auth_type,
+            username,
+            password,
+        } = cli.command
+        {
+            assert_eq!(key, "r");
+            assert_eq!(auth_type, "basic");
+            assert_eq!(username.as_deref(), Some("u"));
+            assert_eq!(password.as_deref(), Some("p"));
+        } else {
+            panic!("Expected RepoCommand::UpstreamAuth");
+        }
+    }
+
+    #[test]
+    fn parse_test_upstream() {
+        let cli = parse(&["test", "test-upstream", "r"]);
+        assert!(matches!(cli.command, RepoCommand::TestUpstream { .. }));
+    }
+
+    // ---- Tree / cat parsing ----
+
+    #[test]
+    fn parse_tree_with_options() {
+        let cli = parse(&["test", "tree", "r", "--path", "sub", "--metadata"]);
+        if let RepoCommand::Tree {
+            key,
+            path,
+            metadata,
+        } = cli.command
+        {
+            assert_eq!(key, "r");
+            assert_eq!(path.as_deref(), Some("sub"));
+            assert!(metadata);
+        } else {
+            panic!("Expected RepoCommand::Tree");
+        }
+    }
+
+    #[test]
+    fn parse_cat() {
+        let cli = parse(&["test", "cat", "r", "a/b.txt", "--max-bytes", "1024"]);
+        if let RepoCommand::Cat {
+            key,
+            path,
+            max_bytes,
+        } = cli.command
+        {
+            assert_eq!(key, "r");
+            assert_eq!(path, "a/b.txt");
+            assert_eq!(max_bytes, Some(1024));
+        } else {
+            panic!("Expected RepoCommand::Cat");
+        }
     }
 
     // ---- Error cases ----
@@ -1022,6 +2345,339 @@ mod tests {
         let global = crate::test_utils::test_global(OutputFormat::Json);
         let result = browse_repo("npm-local", &global).await;
         assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    // ---- handler tests for gap-fill repo ops ----
+
+    #[tokio::test]
+    async fn handler_update_repo() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/repositories/npm-local"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(repo_json("npm-local")))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let body = artifact_keeper_sdk::types::UpdateRepositoryRequest {
+            description: Some("updated".into()),
+            ..Default::default()
+        };
+        let result = update_repo("npm-local", body, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_list_members() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repositories/virt/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "members": [{
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "member_repo_id": "00000000-0000-0000-0000-000000000002",
+                    "member_repo_key": "npm-local",
+                    "member_repo_name": "NPM Local",
+                    "member_repo_type": "local",
+                    "priority": 10,
+                    "created_at": "2026-01-15T12:00:00Z"
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(list_members("virt", &global).await.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_add_member() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/repositories/virt/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "00000000-0000-0000-0000-000000000001",
+                "member_repo_id": "00000000-0000-0000-0000-000000000002",
+                "member_repo_key": "npm-local",
+                "member_repo_name": "NPM Local",
+                "member_repo_type": "local",
+                "priority": 10,
+                "created_at": "2026-01-15T12:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(
+            add_member("virt", "npm-local", Some(10), &global)
+                .await
+                .is_ok()
+        );
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_remove_member() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/repositories/virt/members/npm-local"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(remove_member("virt", "npm-local", &global).await.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_reorder_members() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/repositories/virt/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "members": [] })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let members = vec!["a=1".to_string(), "b=2".to_string()];
+        assert!(reorder_members("virt", &members, &global).await.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn reorder_members_rejects_bad_entry() {
+        let (_server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        // missing '=' separator
+        assert!(
+            reorder_members("virt", &["oops".to_string()], &global)
+                .await
+                .is_err()
+        );
+        // non-numeric priority
+        assert!(
+            reorder_members("virt", &["a=x".to_string()], &global)
+                .await
+                .is_err()
+        );
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_routing_rules_get_set_delete() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        let rules_body = json!({
+            "repository_key": "remote",
+            "rules": [{ "path_pattern": "a/(.*)", "rewrite_to": "b/$1" }]
+        });
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repositories/remote/routing-rules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(rules_body.clone()))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/repositories/remote/routing-rules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(rules_body))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/repositories/remote/routing-rules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(get_routing_rules("remote", &global).await.is_ok());
+        assert!(
+            set_routing_rules("remote", &["a/(.*)=>b/$1".to_string()], &global)
+                .await
+                .is_ok()
+        );
+        assert!(delete_routing_rules("remote", true, &global).await.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn set_routing_rules_rejects_bad_entry() {
+        let (_server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(
+            set_routing_rules("remote", &["no-separator".to_string()], &global)
+                .await
+                .is_err()
+        );
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_cache_ttl_get_set_invalidate() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        let ttl_body = json!({ "repository_key": "remote", "cache_ttl_seconds": 7200_i64 });
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repositories/remote/cache-ttl"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ttl_body.clone()))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/repositories/remote/cache-ttl"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ttl_body))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/repositories/remote/cache/invalidate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "repository_key": "remote", "path": "p/x.tgz", "invalidated": true
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(get_cache_ttl("remote", &global).await.is_ok());
+        assert!(set_cache_ttl("remote", 7200, &global).await.is_ok());
+        assert!(invalidate_cache("remote", "p/x.tgz", &global).await.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_pypi_tracks_list_set_remove() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        let track = json!({
+            "normalized_name": "acme",
+            "repository_key": "pypi-local",
+            "tracks_url": "https://pypi.org/simple/acme/"
+        });
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repositories/pypi-local/pypi-tracks"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "items": [track.clone()] })),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/repositories/pypi-local/pypi-tracks/acme"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(track))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/v1/repositories/pypi-local/pypi-tracks/acme"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(list_pypi_tracks("pypi-local", &global).await.is_ok());
+        assert!(
+            put_pypi_track(
+                "pypi-local",
+                "acme",
+                "https://pypi.org/simple/acme/",
+                &global
+            )
+            .await
+            .is_ok()
+        );
+        assert!(
+            delete_pypi_track("pypi-local", "acme", &global)
+                .await
+                .is_ok()
+        );
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_upstream_auth_and_test() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/repositories/remote/upstream-auth"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/repositories/remote/test-upstream"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(
+            set_upstream_auth("remote", "bearer", None, Some("tok".into()), &global)
+                .await
+                .is_ok()
+        );
+        assert!(test_upstream("remote", &global).await.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_browse_tree() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/tree"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "nodes": [{
+                    "id": "n1",
+                    "name": "express",
+                    "path": "express",
+                    "type": "directory",
+                    "has_children": true,
+                    "size_bytes": null
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(
+            browse_tree("npm-local", Some("express"), true, &global)
+                .await
+                .is_ok()
+        );
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_cat_content() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/tree/content"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("hello world"))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        assert!(
+            cat_content("npm-local", "a/b.txt", Some(1024), &global)
+                .await
+                .is_ok()
+        );
         crate::test_utils::teardown_env();
     }
 

--- a/tests/e2e_repo.rs
+++ b/tests/e2e_repo.rs
@@ -56,3 +56,128 @@ fn repo_list_with_format_filter() {
         .assert()
         .success();
 }
+
+#[test]
+#[ignore = "requires E2E backend"]
+fn repo_update_partial_preserves_other_fields() {
+    let env = common::TestEnv::setup();
+    let key = format!("e2e-upd-{}", std::process::id());
+
+    env.ak_cmd()
+        .args(["repo", "create", &key, "--pkg-format", "npm"])
+        .assert()
+        .success();
+
+    // Set a description via PATCH.
+    env.ak_cmd()
+        .args(["repo", "update", &key, "--description", "e2e-desc"])
+        .assert()
+        .success();
+
+    // Update only the name; description must survive (partial semantics).
+    env.ak_cmd()
+        .args(["repo", "update", &key, "--name", "Renamed"])
+        .assert()
+        .success();
+
+    env.ak_cmd()
+        .args(["repo", "show", &key])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("e2e-desc"))
+        .stdout(predicate::str::contains("Renamed"));
+
+    env.ak_cmd()
+        .args(["repo", "delete", &key, "--yes"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[ignore = "requires E2E backend"]
+fn repo_cache_ttl_get_set_on_remote() {
+    let env = common::TestEnv::setup();
+    let key = format!("e2e-cache-{}", std::process::id());
+
+    env.ak_cmd()
+        .args([
+            "repo",
+            "create",
+            &key,
+            "--pkg-format",
+            "npm",
+            "--repo-type",
+            "remote",
+            "--upstream-url",
+            "https://registry.npmjs.org",
+        ])
+        .assert()
+        .success();
+
+    env.ak_cmd()
+        .args(["repo", "cache", "set-ttl", &key, "3600"])
+        .assert()
+        .success();
+
+    env.ak_cmd()
+        .args(["repo", "cache", "get-ttl", &key])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("3600"));
+
+    env.ak_cmd()
+        .args(["repo", "delete", &key, "--yes"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[ignore = "requires E2E backend"]
+fn repo_virtual_members_lifecycle() {
+    let env = common::TestEnv::setup();
+    let pid = std::process::id();
+    let member = format!("e2e-mem-{pid}");
+    let virt = format!("e2e-virt-{pid}");
+
+    env.ak_cmd()
+        .args(["repo", "create", &member, "--pkg-format", "npm"])
+        .assert()
+        .success();
+    env.ak_cmd()
+        .args([
+            "repo",
+            "create",
+            &virt,
+            "--pkg-format",
+            "npm",
+            "--repo-type",
+            "virtual",
+        ])
+        .assert()
+        .success();
+
+    env.ak_cmd()
+        .args(["repo", "members", "add", &virt, &member, "--priority", "10"])
+        .assert()
+        .success();
+
+    env.ak_cmd()
+        .args(["repo", "members", "list", &virt])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&member));
+
+    env.ak_cmd()
+        .args(["repo", "members", "remove", &virt, &member])
+        .assert()
+        .success();
+
+    env.ak_cmd()
+        .args(["repo", "delete", &virt, "--yes"])
+        .assert()
+        .success();
+    env.ak_cmd()
+        .args(["repo", "delete", &member, "--yes"])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary

Extends the existing `ak repo` command group to cover the `repositories` operations exposed by the v1.4.0 SDK that previously had no CLI surface. Previously only `list`/`show`/`create`/`delete`/`browse` were wired; this adds the remaining ~18 operations as logically grouped subcommands.

| Operation (SDK) | New command |
|---|---|
| `update_repository` (PATCH) | `ak repo update <key> [--name --description --public --allow-anonymous --promotion-only --quota-bytes --quarantine-enabled --quarantine-duration-minutes --index-upstream-url --pypi-upstream-index-path --release-repository-key --new-key]` |
| `list_virtual_members` | `ak repo members list <key>` |
| `add_virtual_member` | `ak repo members add <key> <member_key> [--priority]` |
| `remove_virtual_member` | `ak repo members remove <key> <member_key>` |
| `update_virtual_members` | `ak repo members reorder <key> <member_key=priority>...` |
| `get_routing_rules` | `ak repo routing-rules get <key>` |
| `set_routing_rules` | `ak repo routing-rules set <key> --rule '<pattern>=><rewrite>'...` |
| `delete_routing_rules` | `ak repo routing-rules delete <key>` |
| `get_cache_ttl` | `ak repo cache get-ttl <key>` |
| `set_cache_ttl` | `ak repo cache set-ttl <key> <seconds>` |
| `invalidate_cache` | `ak repo cache invalidate <key> <path>` |
| `list_pypi_tracks` | `ak repo pypi-tracks list <key>` |
| `put_pypi_track` | `ak repo pypi-tracks set <key> <project> --tracks-url <url>` |
| `delete_pypi_track` | `ak repo pypi-tracks remove <key> <project>` |
| `set_upstream_auth` | `ak repo upstream-auth <key> --type <basic\|bearer\|none> [--username --password]` |
| `test_upstream` | `ak repo test-upstream <key>` |
| `get_tree` | `ak repo tree <key> [--path --metadata]` |
| `get_content` | `ak repo cat <key> <path> [--max-bytes]` |

`repo update` follows the backend's PATCH semantics: each field is an `Option`, and only fields the user provides are serialized (the SDK request type uses `skip_serializing_if`), so a targeted update never clobbers untouched settings. `upstream-auth` prompts for the secret interactively when `--password` is omitted for `basic`/`bearer` (unless `--no-input`).

## Test Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings -A dead_code`
- [x] `cargo test --workspace` (1572 unit tests pass; adds parse + wiremock handler tests for every new subcommand)
- [x] `cargo build --release`
- [x] E2E tests added (`tests/e2e_repo.rs`): partial-update field preservation, cache TTL get/set, virtual member lifecycle — verified against a live v1.4.0 backend
- [x] Manual smoke test against a live v1.4.0 backend for all 18 operations

## API Changes

None. This is a client-only change that wires existing v1.4.0 SDK operations to CLI commands. No new endpoints or SDK regeneration.

Closes #111