### PR TITLE
feat(promotion): wire the unwired promotion operations into `ak promotion`

### DIFF
--- a/src/commands/promotion.rs
+++ b/src/commands/promotion.rs
@@ -33,10 +33,57 @@ pub enum PromotionCommand {
         skip_checks: bool,
     },
 
+    /// Promote multiple artifacts from a staging repo in a single request
+    BulkPromote {
+        /// Source repository key
+        #[arg(long)]
+        from: String,
+
+        /// Artifact IDs to promote (comma-separated or repeated)
+        #[arg(long = "artifact", value_delimiter = ',', required = true)]
+        artifacts: Vec<String>,
+
+        /// Target repository key (defaults to the repo's linked release target)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Optional notes
+        #[arg(long)]
+        notes: Option<String>,
+
+        /// Skip policy checks
+        #[arg(long)]
+        skip_checks: bool,
+    },
+
+    /// Reject an artifact promotion
+    Reject {
+        /// Source repository key
+        #[arg(long)]
+        from: String,
+
+        /// Artifact ID
+        artifact: String,
+
+        /// Reason for rejection
+        #[arg(long)]
+        reason: String,
+
+        /// Optional notes
+        #[arg(long)]
+        notes: Option<String>,
+    },
+
     /// Manage promotion rules
     Rule {
         #[command(subcommand)]
         command: PromotionRuleCommand,
+    },
+
+    /// Manage a staging repository's release target
+    ReleaseTarget {
+        #[command(subcommand)]
+        command: ReleaseTargetCommand,
     },
 
     /// View promotion history
@@ -68,6 +115,12 @@ pub enum PromotionRuleCommand {
         from: Option<String>,
     },
 
+    /// Show a promotion rule
+    Get {
+        /// Rule ID
+        id: String,
+    },
+
     /// Create a promotion rule
     Create {
         /// Rule name
@@ -86,6 +139,54 @@ pub enum PromotionRuleCommand {
         auto: bool,
     },
 
+    /// Update a promotion rule
+    Update {
+        /// Rule ID
+        id: String,
+
+        /// New rule name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Enable or disable auto-promotion
+        #[arg(long)]
+        auto: Option<bool>,
+
+        /// Enable or disable the rule
+        #[arg(long)]
+        enabled: Option<bool>,
+
+        /// Minimum hours an artifact must stay in staging
+        #[arg(long)]
+        min_staging_hours: Option<i32>,
+
+        /// Maximum artifact age in days
+        #[arg(long)]
+        max_artifact_age_days: Option<i32>,
+
+        /// Maximum allowed CVE severity (none, low, medium, high, critical)
+        #[arg(long)]
+        max_cve_severity: Option<String>,
+
+        /// Minimum health score (0-100)
+        #[arg(long)]
+        min_health_score: Option<i32>,
+
+        /// Allowed licenses (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        allowed_licenses: Option<Vec<String>>,
+
+        /// Require artifacts to be signed
+        #[arg(long)]
+        require_signature: Option<bool>,
+    },
+
+    /// Evaluate a promotion rule against candidate artifacts
+    Evaluate {
+        /// Rule ID
+        id: String,
+    },
+
     /// Delete a promotion rule
     Delete {
         /// Rule ID
@@ -94,6 +195,27 @@ pub enum PromotionRuleCommand {
         /// Skip confirmation prompt
         #[arg(long)]
         yes: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ReleaseTargetCommand {
+    /// Show the release target linked to a staging repository
+    Get {
+        /// Staging repository key
+        #[arg(long)]
+        repo: String,
+    },
+
+    /// Link (or unlink) a staging repository's release target
+    Set {
+        /// Staging repository key
+        #[arg(long)]
+        repo: String,
+
+        /// Release repository key to link (omit to unlink)
+        #[arg(long)]
+        release_repo: Option<String>,
     },
 }
 
@@ -109,15 +231,75 @@ impl PromotionCommand {
             } => {
                 promote_artifact(&from, &artifact, &to, notes.as_deref(), skip_checks, global).await
             }
+            Self::BulkPromote {
+                from,
+                artifacts,
+                to,
+                notes,
+                skip_checks,
+            } => {
+                bulk_promote(
+                    &from,
+                    &artifacts,
+                    to.as_deref(),
+                    notes.as_deref(),
+                    skip_checks,
+                    global,
+                )
+                .await
+            }
+            Self::Reject {
+                from,
+                artifact,
+                reason,
+                notes,
+            } => reject_artifact(&from, &artifact, &reason, notes.as_deref(), global).await,
             Self::Rule { command } => match command {
                 PromotionRuleCommand::List { from } => list_rules(from.as_deref(), global).await,
+                PromotionRuleCommand::Get { id } => get_rule(&id, global).await,
                 PromotionRuleCommand::Create {
                     name,
                     from,
                     to,
                     auto,
                 } => create_rule(&name, &from, &to, auto, global).await,
+                PromotionRuleCommand::Update {
+                    id,
+                    name,
+                    auto,
+                    enabled,
+                    min_staging_hours,
+                    max_artifact_age_days,
+                    max_cve_severity,
+                    min_health_score,
+                    allowed_licenses,
+                    require_signature,
+                } => {
+                    update_rule(
+                        &id,
+                        RuleUpdate {
+                            name,
+                            auto,
+                            enabled,
+                            min_staging_hours,
+                            max_artifact_age_days,
+                            max_cve_severity,
+                            min_health_score,
+                            allowed_licenses,
+                            require_signature,
+                        },
+                        global,
+                    )
+                    .await
+                }
+                PromotionRuleCommand::Evaluate { id } => evaluate_rule(&id, global).await,
                 PromotionRuleCommand::Delete { id, yes } => delete_rule(&id, yes, global).await,
+            },
+            Self::ReleaseTarget { command } => match command {
+                ReleaseTargetCommand::Get { repo } => get_release_target(&repo, global).await,
+                ReleaseTargetCommand::Set { repo, release_repo } => {
+                    set_release_target(&repo, release_repo.as_deref(), global).await
+                }
             },
             Self::History {
                 repo,
@@ -127,6 +309,20 @@ impl PromotionCommand {
             } => promotion_history(&repo, status.as_deref(), page, per_page, global).await,
         }
     }
+}
+
+/// Optional fields for a promotion-rule update. Grouped into a struct to keep
+/// the `update_rule` signature within clippy's argument-count budget.
+struct RuleUpdate {
+    name: Option<String>,
+    auto: Option<bool>,
+    enabled: Option<bool>,
+    min_staging_hours: Option<i32>,
+    max_artifact_age_days: Option<i32>,
+    max_cve_severity: Option<String>,
+    min_health_score: Option<i32>,
+    allowed_licenses: Option<Vec<String>>,
+    require_signature: Option<bool>,
 }
 
 async fn promote_artifact(
@@ -335,6 +531,399 @@ async fn delete_rule(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Resul
     );
 
     Ok(())
+}
+
+fn rule_detail(
+    rule: &artifact_keeper_sdk::types::PromotionRuleResponse,
+) -> (serde_json::Value, String) {
+    let info = serde_json::json!({
+        "id": rule.id.to_string(),
+        "name": rule.name,
+        "source_repo_id": rule.source_repo_id.to_string(),
+        "target_repo_id": rule.target_repo_id.to_string(),
+        "auto_promote": rule.auto_promote,
+        "is_enabled": rule.is_enabled,
+        "min_staging_hours": rule.min_staging_hours,
+        "max_artifact_age_days": rule.max_artifact_age_days,
+        "max_cve_severity": rule.max_cve_severity,
+        "min_health_score": rule.min_health_score,
+        "allowed_licenses": rule.allowed_licenses,
+        "require_signature": rule.require_signature,
+        "created_at": rule.created_at.to_rfc3339(),
+        "updated_at": rule.updated_at.to_rfc3339(),
+    });
+
+    let licenses = rule
+        .allowed_licenses
+        .as_ref()
+        .map(|l| l.join(", "))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "-".to_string());
+
+    let table_str = format!(
+        "ID:               {}\n\
+         Name:             {}\n\
+         Source:           {}\n\
+         Target:           {}\n\
+         Auto-promote:     {}\n\
+         Enabled:          {}\n\
+         Min staging (h):  {}\n\
+         Max age (days):   {}\n\
+         Max CVE severity: {}\n\
+         Min health score: {}\n\
+         Allowed licenses: {}\n\
+         Require signature: {}\n\
+         Created:          {}\n\
+         Updated:          {}",
+        rule.id,
+        rule.name,
+        rule.source_repo_id,
+        rule.target_repo_id,
+        if rule.auto_promote { "yes" } else { "no" },
+        if rule.is_enabled { "yes" } else { "no" },
+        opt_display(&rule.min_staging_hours),
+        opt_display(&rule.max_artifact_age_days),
+        rule.max_cve_severity.as_deref().unwrap_or("-"),
+        opt_display(&rule.min_health_score),
+        licenses,
+        if rule.require_signature { "yes" } else { "no" },
+        rule.created_at.format("%Y-%m-%d %H:%M:%S UTC"),
+        rule.updated_at.format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+
+    (info, table_str)
+}
+
+fn opt_display<T: std::fmt::Display>(v: &Option<T>) -> String {
+    v.as_ref()
+        .map(|x| x.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+async fn get_rule(id: &str, global: &GlobalArgs) -> Result<()> {
+    let rule_id = parse_uuid(id, "rule")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching promotion rule...");
+
+    let rule = client
+        .get_rule()
+        .id(rule_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get promotion rule", e))?;
+
+    spinner.finish_and_clear();
+
+    let (info, table_str) = rule_detail(&rule);
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn update_rule(id: &str, update: RuleUpdate, global: &GlobalArgs) -> Result<()> {
+    let rule_id = parse_uuid(id, "rule")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Updating promotion rule...");
+
+    let body = artifact_keeper_sdk::types::UpdateRuleRequest {
+        name: update.name,
+        auto_promote: update.auto,
+        is_enabled: update.enabled,
+        min_staging_hours: update.min_staging_hours,
+        max_artifact_age_days: update.max_artifact_age_days,
+        max_cve_severity: update.max_cve_severity,
+        min_health_score: update.min_health_score,
+        allowed_licenses: update.allowed_licenses,
+        require_signature: update.require_signature,
+    };
+
+    let rule = client
+        .update_rule()
+        .id(rule_id)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("update promotion rule", e))?;
+
+    spinner.finish_and_clear();
+
+    emit_mutation(
+        &*rule,
+        &rule.id.to_string(),
+        &format!("Promotion rule '{}' updated (ID: {}).", rule.name, rule.id),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn evaluate_rule(id: &str, global: &GlobalArgs) -> Result<()> {
+    let rule_id = parse_uuid(id, "rule")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Evaluating promotion rule...");
+
+    let resp = client
+        .evaluate_rule()
+        .id(rule_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("evaluate promotion rule", e))?;
+
+    spinner.finish_and_clear();
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for entry in &resp.results {
+            println!("{}", entry.artifact_id);
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp
+        .results
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "artifact_id": r.artifact_id.to_string(),
+                "passed": r.passed,
+                "violations": r.violations,
+            })
+        })
+        .collect();
+
+    let table_str = {
+        let mut table = new_table(vec!["ARTIFACT", "PASSED", "VIOLATIONS"]);
+        for r in &resp.results {
+            let id_short = short_id(&r.artifact_id);
+            let passed = if r.passed { "yes" } else { "no" };
+            let violations = if r.violations.is_empty() {
+                "-".to_string()
+            } else {
+                r.violations.join("; ")
+            };
+            table.add_row(vec![&id_short, passed, &violations]);
+        }
+        table.to_string()
+    };
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    eprintln!(
+        "Rule '{}': {} passed, {} failed of {} artifacts.",
+        resp.rule_name, resp.passed, resp.failed, resp.total_artifacts
+    );
+
+    Ok(())
+}
+
+async fn bulk_promote(
+    from: &str,
+    artifact_ids: &[String],
+    to: Option<&str>,
+    notes: Option<&str>,
+    skip_checks: bool,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let mut ids = Vec::with_capacity(artifact_ids.len());
+    for a in artifact_ids {
+        ids.push(parse_uuid(a, "artifact")?);
+    }
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Promoting artifacts...");
+
+    let body = artifact_keeper_sdk::types::BulkPromoteRequest {
+        artifact_ids: ids,
+        target_repository: to.map(|s| s.to_string()),
+        notes: notes.map(|s| s.to_string()),
+        skip_policy_check: skip_checks.then_some(true),
+    };
+
+    let resp = client
+        .promote_artifacts_bulk()
+        .key(from)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("bulk-promote artifacts", e))?;
+
+    spinner.finish_and_clear();
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for r in &resp.results {
+            if let Some(pid) = &r.promotion_id {
+                println!("{pid}");
+            }
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp
+        .results
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "promoted": r.promoted,
+                "source": r.source,
+                "target": r.target,
+                "promotion_id": r.promotion_id.map(|id| id.to_string()),
+                "message": r.message,
+            })
+        })
+        .collect();
+
+    let table_str = {
+        let mut table = new_table(vec!["PROMOTED", "SOURCE", "TARGET", "MESSAGE"]);
+        for r in &resp.results {
+            let promoted = if r.promoted { "yes" } else { "no" };
+            let msg = r.message.as_deref().unwrap_or("-");
+            table.add_row(vec![promoted, &r.source, &r.target, msg]);
+        }
+        table.to_string()
+    };
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    eprintln!(
+        "{} promoted, {} failed of {} artifacts.",
+        resp.promoted, resp.failed, resp.total
+    );
+
+    Ok(())
+}
+
+async fn reject_artifact(
+    from: &str,
+    artifact_id: &str,
+    reason: &str,
+    notes: Option<&str>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let aid = parse_uuid(artifact_id, "artifact")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Rejecting artifact...");
+
+    let body = artifact_keeper_sdk::types::RejectArtifactRequest {
+        reason: reason.to_string(),
+        notes: notes.map(|s| s.to_string()),
+    };
+
+    let resp = client
+        .reject_artifact()
+        .key(from)
+        .artifact_id(aid)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("reject artifact", e))?;
+
+    spinner.finish_and_clear();
+
+    emit_mutation(
+        &*resp,
+        &resp.rejection_id.to_string(),
+        &format!(
+            "Artifact {} rejected from {} (reason: {}).",
+            resp.artifact_id, resp.source, resp.reason
+        ),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn get_release_target(repo: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching release target...");
+
+    let resp = client
+        .get_release_target()
+        .key(repo)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get release target", e))?;
+
+    spinner.finish_and_clear();
+
+    let (info, table_str) = release_target_detail(&resp);
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn set_release_target(
+    repo: &str,
+    release_repo: Option<&str>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for(global)?;
+    let action = if release_repo.is_some() {
+        "Linking release target..."
+    } else {
+        "Unlinking release target..."
+    };
+    let spinner = output::spinner(action);
+
+    let body = artifact_keeper_sdk::types::SetReleaseTargetRequest {
+        release_repository_key: release_repo.map(|s| s.to_string()),
+    };
+
+    let resp = client
+        .set_release_target()
+        .key(repo)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("set release target", e))?;
+
+    spinner.finish_and_clear();
+
+    let human = if resp.linked {
+        format!(
+            "Release target for '{}' set to '{}'.",
+            repo,
+            resp.release_repository_key.as_deref().unwrap_or("-")
+        )
+    } else {
+        format!("Release target for '{repo}' unlinked.")
+    };
+
+    let (info, _table) = release_target_detail(&resp);
+    emit_mutation(&info, repo, &human, global);
+
+    Ok(())
+}
+
+fn release_target_detail(
+    resp: &artifact_keeper_sdk::types::ReleaseTargetResponse,
+) -> (serde_json::Value, String) {
+    let info = serde_json::json!({
+        "linked": resp.linked,
+        "release_repository_id": resp.release_repository_id.map(|id| id.to_string()),
+        "release_repository_key": resp.release_repository_key,
+    });
+
+    let table_str = format!(
+        "Linked:          {}\n\
+         Release repo:    {}\n\
+         Release repo ID: {}",
+        if resp.linked { "yes" } else { "no" },
+        resp.release_repository_key.as_deref().unwrap_or("-"),
+        resp.release_repository_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+    );
+
+    (info, table_str)
 }
 
 fn format_rule_table(items: &[serde_json::Value]) -> String {
@@ -1093,6 +1682,516 @@ mod tests {
 
         let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
         let result = promotion_history("maven-releases", None, 1, 20, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    // ---- parsing: bulk-promote / reject / rule get-update-evaluate / release-target ----
+
+    #[test]
+    fn parse_bulk_promote_minimal() {
+        let cli = parse(&[
+            "test",
+            "bulk-promote",
+            "--from",
+            "staging",
+            "--artifact",
+            "00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000002",
+        ]);
+        match cli.command {
+            PromotionCommand::BulkPromote {
+                from,
+                artifacts,
+                to,
+                notes,
+                skip_checks,
+            } => {
+                assert_eq!(from, "staging");
+                assert_eq!(artifacts.len(), 2);
+                assert!(to.is_none());
+                assert!(notes.is_none());
+                assert!(!skip_checks);
+            }
+            _ => panic!("expected BulkPromote"),
+        }
+    }
+
+    #[test]
+    fn parse_bulk_promote_with_options() {
+        let cli = parse(&[
+            "test",
+            "bulk-promote",
+            "--from",
+            "staging",
+            "--artifact",
+            "id1",
+            "--artifact",
+            "id2",
+            "--to",
+            "releases",
+            "--notes",
+            "batch",
+            "--skip-checks",
+        ]);
+        match cli.command {
+            PromotionCommand::BulkPromote {
+                artifacts,
+                to,
+                notes,
+                skip_checks,
+                ..
+            } => {
+                assert_eq!(artifacts, vec!["id1", "id2"]);
+                assert_eq!(to.as_deref(), Some("releases"));
+                assert_eq!(notes.as_deref(), Some("batch"));
+                assert!(skip_checks);
+            }
+            _ => panic!("expected BulkPromote"),
+        }
+    }
+
+    #[test]
+    fn parse_bulk_promote_missing_artifact() {
+        let result = try_parse(&["test", "bulk-promote", "--from", "staging"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_reject_minimal() {
+        let cli = parse(&[
+            "test",
+            "reject",
+            "--from",
+            "staging",
+            "artifact-id",
+            "--reason",
+            "cve",
+        ]);
+        match cli.command {
+            PromotionCommand::Reject {
+                from,
+                artifact,
+                reason,
+                notes,
+            } => {
+                assert_eq!(from, "staging");
+                assert_eq!(artifact, "artifact-id");
+                assert_eq!(reason, "cve");
+                assert!(notes.is_none());
+            }
+            _ => panic!("expected Reject"),
+        }
+    }
+
+    #[test]
+    fn parse_reject_missing_reason() {
+        let result = try_parse(&["test", "reject", "--from", "staging", "artifact-id"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_rule_get() {
+        let cli = parse(&["test", "rule", "get", "rule-id"]);
+        match cli.command {
+            PromotionCommand::Rule {
+                command: PromotionRuleCommand::Get { id },
+            } => assert_eq!(id, "rule-id"),
+            _ => panic!("expected Rule Get"),
+        }
+    }
+
+    #[test]
+    fn parse_rule_update_fields() {
+        let cli = parse(&[
+            "test",
+            "rule",
+            "update",
+            "rule-id",
+            "--name",
+            "renamed",
+            "--auto",
+            "true",
+            "--enabled",
+            "false",
+            "--min-staging-hours",
+            "24",
+            "--max-cve-severity",
+            "high",
+            "--allowed-licenses",
+            "MIT,Apache-2.0",
+            "--require-signature",
+            "true",
+        ]);
+        match cli.command {
+            PromotionCommand::Rule {
+                command:
+                    PromotionRuleCommand::Update {
+                        id,
+                        name,
+                        auto,
+                        enabled,
+                        min_staging_hours,
+                        max_cve_severity,
+                        allowed_licenses,
+                        require_signature,
+                        ..
+                    },
+            } => {
+                assert_eq!(id, "rule-id");
+                assert_eq!(name.as_deref(), Some("renamed"));
+                assert_eq!(auto, Some(true));
+                assert_eq!(enabled, Some(false));
+                assert_eq!(min_staging_hours, Some(24));
+                assert_eq!(max_cve_severity.as_deref(), Some("high"));
+                assert_eq!(
+                    allowed_licenses,
+                    Some(vec!["MIT".to_string(), "Apache-2.0".to_string()])
+                );
+                assert_eq!(require_signature, Some(true));
+            }
+            _ => panic!("expected Rule Update"),
+        }
+    }
+
+    #[test]
+    fn parse_rule_update_no_fields() {
+        let cli = parse(&["test", "rule", "update", "rule-id"]);
+        match cli.command {
+            PromotionCommand::Rule {
+                command: PromotionRuleCommand::Update { id, name, auto, .. },
+            } => {
+                assert_eq!(id, "rule-id");
+                assert!(name.is_none());
+                assert!(auto.is_none());
+            }
+            _ => panic!("expected Rule Update"),
+        }
+    }
+
+    #[test]
+    fn parse_rule_evaluate() {
+        let cli = parse(&["test", "rule", "evaluate", "rule-id"]);
+        match cli.command {
+            PromotionCommand::Rule {
+                command: PromotionRuleCommand::Evaluate { id },
+            } => assert_eq!(id, "rule-id"),
+            _ => panic!("expected Rule Evaluate"),
+        }
+    }
+
+    #[test]
+    fn parse_release_target_get() {
+        let cli = parse(&["test", "release-target", "get", "--repo", "maven-staging"]);
+        match cli.command {
+            PromotionCommand::ReleaseTarget {
+                command: ReleaseTargetCommand::Get { repo },
+            } => assert_eq!(repo, "maven-staging"),
+            _ => panic!("expected ReleaseTarget Get"),
+        }
+    }
+
+    #[test]
+    fn parse_release_target_set_link() {
+        let cli = parse(&[
+            "test",
+            "release-target",
+            "set",
+            "--repo",
+            "maven-staging",
+            "--release-repo",
+            "maven-releases",
+        ]);
+        match cli.command {
+            PromotionCommand::ReleaseTarget {
+                command: ReleaseTargetCommand::Set { repo, release_repo },
+            } => {
+                assert_eq!(repo, "maven-staging");
+                assert_eq!(release_repo.as_deref(), Some("maven-releases"));
+            }
+            _ => panic!("expected ReleaseTarget Set"),
+        }
+    }
+
+    #[test]
+    fn parse_release_target_set_unlink() {
+        let cli = parse(&["test", "release-target", "set", "--repo", "maven-staging"]);
+        match cli.command {
+            PromotionCommand::ReleaseTarget {
+                command: ReleaseTargetCommand::Set { release_repo, .. },
+            } => assert!(release_repo.is_none()),
+            _ => panic!("expected ReleaseTarget Set"),
+        }
+    }
+
+    // ---- detail formatters ----
+
+    #[test]
+    fn rule_detail_renders() {
+        let rule: artifact_keeper_sdk::types::PromotionRuleResponse =
+            serde_json::from_value(rule_json()).unwrap();
+        let (info, table) = rule_detail(&rule);
+        assert_eq!(info["name"], "staging-to-prod");
+        assert!(table.contains("staging-to-prod"));
+        assert!(table.contains("Auto-promote:"));
+        assert!(table.contains("Require signature:"));
+    }
+
+    #[test]
+    fn release_target_detail_linked() {
+        let resp: artifact_keeper_sdk::types::ReleaseTargetResponse =
+            serde_json::from_value(json!({
+                "linked": true,
+                "release_repository_id": NIL_UUID,
+                "release_repository_key": "maven-releases"
+            }))
+            .unwrap();
+        let (info, table) = release_target_detail(&resp);
+        assert_eq!(info["linked"], true);
+        assert!(table.contains("maven-releases"));
+        assert!(table.contains("yes"));
+    }
+
+    #[test]
+    fn release_target_detail_unlinked() {
+        let resp: artifact_keeper_sdk::types::ReleaseTargetResponse =
+            serde_json::from_value(json!({
+                "linked": false
+            }))
+            .unwrap();
+        let (info, table) = release_target_detail(&resp);
+        assert_eq!(info["linked"], false);
+        assert!(table.contains("no"));
+    }
+
+    // ---- wiremock handler tests: new ops ----
+
+    #[tokio::test]
+    async fn handler_get_rule() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path(format!("/api/v1/promotion-rules/{NIL_UUID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(rule_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = get_rule(NIL_UUID, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_update_rule() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path(format!("/api/v1/promotion-rules/{NIL_UUID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(rule_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let update = RuleUpdate {
+            name: Some("renamed".to_string()),
+            auto: Some(true),
+            enabled: None,
+            min_staging_hours: Some(12),
+            max_artifact_age_days: None,
+            max_cve_severity: Some("high".to_string()),
+            min_health_score: None,
+            allowed_licenses: Some(vec!["MIT".to_string()]),
+            require_signature: Some(true),
+        };
+        let result = update_rule(NIL_UUID, update, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_evaluate_rule() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path(format!("/api/v1/promotion-rules/{NIL_UUID}/evaluate")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "rule_id": NIL_UUID,
+                "rule_name": "staging-to-prod",
+                "total_artifacts": 2_u64,
+                "passed": 1_u64,
+                "failed": 1_u64,
+                "results": [
+                    { "artifact_id": NIL_UUID, "passed": true, "violations": [] },
+                    { "artifact_id": NIL_UUID, "passed": false, "violations": ["cve too high"] }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = evaluate_rule(NIL_UUID, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_bulk_promote() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/promotion/repositories/staging/promote"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 2_u64,
+                "promoted": 2_u64,
+                "failed": 0_u64,
+                "results": [
+                    {
+                        "promoted": true,
+                        "source": "staging",
+                        "target": "releases",
+                        "promotion_id": NIL_UUID,
+                        "policy_violations": []
+                    },
+                    {
+                        "promoted": true,
+                        "source": "staging",
+                        "target": "releases",
+                        "promotion_id": NIL_UUID,
+                        "policy_violations": []
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let ids = vec![NIL_UUID.to_string(), NIL_UUID.to_string()];
+        let result = bulk_promote("staging", &ids, Some("releases"), None, false, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_bulk_promote_quiet() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/promotion/repositories/staging/promote"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "total": 1_u64,
+                "promoted": 1_u64,
+                "failed": 0_u64,
+                "results": [{
+                    "promoted": true,
+                    "source": "staging",
+                    "target": "releases",
+                    "promotion_id": NIL_UUID,
+                    "policy_violations": []
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let ids = vec![NIL_UUID.to_string()];
+        let result = bulk_promote("staging", &ids, None, None, false, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_reject_artifact() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/api/v1/promotion/repositories/staging/artifacts/{NIL_UUID}/reject"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "rejected": true,
+                "rejection_id": NIL_UUID,
+                "artifact_id": NIL_UUID,
+                "source": "staging",
+                "reason": "cve too high"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = reject_artifact("staging", NIL_UUID, "cve too high", None, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_get_release_target() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/promotion/repositories/maven-staging/release-target",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "linked": true,
+                "release_repository_id": NIL_UUID,
+                "release_repository_key": "maven-releases"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = get_release_target("maven-staging", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_set_release_target_link() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path(
+                "/api/v1/promotion/repositories/maven-staging/release-target",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "linked": true,
+                "release_repository_id": NIL_UUID,
+                "release_repository_key": "maven-releases"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Table);
+        let result = set_release_target("maven-staging", Some("maven-releases"), &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_set_release_target_unlink() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path(
+                "/api/v1/promotion/repositories/maven-staging/release-target",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "linked": false
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = set_release_target("maven-staging", None, &global).await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
     }


### PR DESCRIPTION
## Summary

Extends the existing `ak promotion` command group to cover the promotion operations exposed by the v1.4.0 SDK (`ClientPromotionExt`) that previously had no CLI surface. Only 5 of 12 operations were wired (`promote`, `rule list`, `rule create`, `rule delete`, `history`); this adds the remaining 7 as subcommands that follow the group's existing structure.

| Operation (SDK) | New command |
|---|---|
| `promote_artifacts_bulk` | `ak promotion bulk-promote --from <key> --artifact <id>... [--to <key>] [--notes] [--skip-checks]` |
| `reject_artifact` | `ak promotion reject --from <key> <artifact_id> --reason <text> [--notes]` |
| `get_rule` | `ak promotion rule get <id>` |
| `update_rule` | `ak promotion rule update <id> [--name --auto --enabled --min-staging-hours --max-artifact-age-days --max-cve-severity --min-health-score --allowed-licenses --require-signature]` |
| `evaluate_rule` | `ak promotion rule evaluate <id>` |
| `get_release_target` | `ak promotion release-target get --repo <key>` |
| `set_release_target` | `ak promotion release-target set --repo <key> [--release-repo <key>]` |

Notes:
- `rule update` follows the backend's PUT-with-optional-fields semantics: every field is an `Option`, and the SDK request type uses `skip_serializing_if`, so only fields the user provides are sent — untouched rule settings are preserved. Tri-state booleans (`--auto`, `--enabled`, `--require-signature`) take an explicit `true`/`false` value so they can be left unchanged, matching the existing convention in `quality_gate`/`license`.
- `release-target set` links the staging repo to a release repo when `--release-repo` is given, and unlinks it when omitted.
- `bulk-promote --to` is optional; when omitted the backend uses the staging repo's linked release target.

## Test Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings -A dead_code` (clean; the pre-existing repo-wide `useless_borrows_in_formatting` findings are untouched)
- [x] `cargo test --workspace` (adds 27 tests: arg-parsing, detail formatters, and wiremock handler tests for every new op; 64 promotion tests pass)
- [x] `cargo build --release`
- [x] Manual smoke test against a live v1.4.0 backend for all 7 operations (release-target get/set/unlink, rule get/update/evaluate, bulk-promote, reject)

## API Changes

None. Client-only change wiring existing v1.4.0 SDK operations to CLI commands. No new endpoints, no SDK regeneration.

Closes #119
