### PR TITLE
feat(cli): wire remaining security/supply-chain single-op gaps

### DIFF
--- a/src/commands/approval.rs
+++ b/src/commands/approval.rs
@@ -28,6 +28,28 @@ pub enum ApprovalCommand {
         per_page: i32,
     },
 
+    /// Request approval to promote an artifact between repositories
+    Request {
+        /// Artifact ID to promote
+        artifact_id: String,
+
+        /// Source repository key
+        #[arg(long)]
+        source: String,
+
+        /// Target repository key
+        #[arg(long)]
+        target: String,
+
+        /// Notes for the approver
+        #[arg(long)]
+        notes: Option<String>,
+
+        /// Skip the promotion policy check
+        #[arg(long)]
+        skip_policy_check: bool,
+    },
+
     /// Show approval details
     Show {
         /// Approval ID
@@ -64,6 +86,23 @@ impl ApprovalCommand {
                 page,
                 per_page,
             } => list_approvals(status.as_deref(), repo.as_deref(), page, per_page, global).await,
+            Self::Request {
+                artifact_id,
+                source,
+                target,
+                notes,
+                skip_policy_check,
+            } => {
+                request_approval(
+                    &artifact_id,
+                    &source,
+                    &target,
+                    notes.as_deref(),
+                    skip_policy_check,
+                    global,
+                )
+                .await
+            }
             Self::Show { id } => show_approval(&id, global).await,
             Self::Approve { id, comment } => {
                 review_promotion(&id, comment.as_deref(), true, global).await
@@ -165,6 +204,62 @@ async fn list_approvals(
             resp.pagination.page, resp.pagination.total_pages, resp.pagination.total
         );
     }
+
+    Ok(())
+}
+
+async fn request_approval(
+    artifact_id: &str,
+    source: &str,
+    target: &str,
+    notes: Option<&str>,
+    skip_policy_check: bool,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let aid = parse_uuid(artifact_id, "artifact")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Requesting approval...");
+
+    let body = artifact_keeper_sdk::types::ApprovalRequest {
+        artifact_id: aid,
+        source_repository: source.to_string(),
+        target_repository: target.to_string(),
+        notes: notes.map(|s| s.to_string()),
+        skip_policy_check: skip_policy_check.then_some(true),
+    };
+
+    let approval = client
+        .request_approval()
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("request approval", e))?
+        .into_inner();
+
+    spinner.finish_and_clear();
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        println!("{}", approval.id);
+        return Ok(());
+    }
+
+    let info = serde_json::json!({
+        "id": approval.id.to_string(),
+        "artifact_id": approval.artifact_id.to_string(),
+        "source_repository": approval.source_repository,
+        "target_repository": approval.target_repository,
+        "status": approval.status,
+        "requested_by": approval.requested_by.to_string(),
+        "requested_at": approval.requested_at.to_rfc3339(),
+        "reviewed_by": approval.reviewed_by.map(|u| u.to_string()),
+        "reviewed_at": approval.reviewed_at.map(|t| t.to_rfc3339()),
+        "notes": approval.notes,
+        "review_notes": approval.review_notes,
+    });
+
+    let table_str = format_approval_detail(&info);
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
 
     Ok(())
 }
@@ -433,6 +528,46 @@ mod tests {
     #[test]
     fn parse_show_missing_id() {
         let result = try_parse(&["test", "show"]);
+        assert!(result.is_err());
+    }
+
+    // ---- parsing: request ----
+
+    #[test]
+    fn parse_request() {
+        let cli = parse(&[
+            "test",
+            "request",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "--source",
+            "maven-staging",
+            "--target",
+            "maven-releases",
+            "--notes",
+            "ready for prod",
+            "--skip-policy-check",
+        ]);
+        match cli.command {
+            ApprovalCommand::Request {
+                artifact_id,
+                source,
+                target,
+                notes,
+                skip_policy_check,
+            } => {
+                assert_eq!(artifact_id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+                assert_eq!(source, "maven-staging");
+                assert_eq!(target, "maven-releases");
+                assert_eq!(notes.as_deref(), Some("ready for prod"));
+                assert!(skip_policy_check);
+            }
+            _ => panic!("expected Request"),
+        }
+    }
+
+    #[test]
+    fn parse_request_missing_target() {
+        let result = try_parse(&["test", "request", "some-id", "--source", "staging"]);
         assert!(result.is_err());
     }
 
@@ -732,6 +867,56 @@ mod tests {
 
         let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
         let result = show_approval(NIL_UUID, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_request_approval() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/approval/request"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(approval_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = request_approval(
+            NIL_UUID,
+            "maven-staging",
+            "maven-releases",
+            Some("ready for prod"),
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_request_approval_quiet() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/approval/request"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(approval_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = request_approval(
+            NIL_UUID,
+            "maven-staging",
+            "maven-releases",
+            None,
+            true,
+            &global,
+        )
+        .await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
     }

--- a/src/commands/artifact.rs
+++ b/src/commands/artifact.rs
@@ -1,13 +1,15 @@
 use std::path::{Path, PathBuf};
 
-use artifact_keeper_sdk::{ClientPromotionExt, ClientRepositoriesExt, ClientSearchExt};
+use artifact_keeper_sdk::{
+    ClientArtifactsExt, ClientPromotionExt, ClientRepositoriesExt, ClientSearchExt,
+};
 use clap::Subcommand;
 use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 use futures::StreamExt;
 use miette::{IntoDiagnostic, Result};
 
 use super::client::{build_client, client_for, client_for_optional_auth};
-use super::helpers::emit_mutation;
+use super::helpers::{emit_mutation, parse_uuid};
 use crate::cli::GlobalArgs;
 use crate::config::AppConfig;
 use crate::error::AkError;
@@ -75,6 +77,24 @@ pub enum ArtifactCommand {
 
         /// Artifact path
         path: String,
+    },
+
+    /// Show an artifact by its global ID
+    Show {
+        /// Artifact ID
+        id: String,
+    },
+
+    /// Show format-specific metadata for an artifact by its global ID
+    Metadata {
+        /// Artifact ID
+        id: String,
+    },
+
+    /// Show download statistics for an artifact by its global ID
+    Stats {
+        /// Artifact ID
+        id: String,
     },
 
     /// Delete an artifact
@@ -152,6 +172,9 @@ impl ArtifactCommand {
                 per_page,
             } => list(&repo, search.as_deref(), page, per_page, global).await,
             Self::Info { repo, path } => info(&repo, &path, global).await,
+            Self::Show { id } => show_by_id(&id, global).await,
+            Self::Metadata { id } => show_metadata(&id, global).await,
+            Self::Stats { id } => show_stats(&id, global).await,
             Self::Delete { repo, path, yes } => delete(&repo, &path, yes, global).await,
             Self::Search {
                 query,
@@ -509,6 +532,135 @@ async fn info(repo: &str, artifact_path: &str, global: &GlobalArgs) -> Result<()
         artifact.download_count,
         artifact.repository_key,
         artifact.created_at.format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn show_by_id(id: &str, global: &GlobalArgs) -> Result<()> {
+    let artifact_id = parse_uuid(id, "artifact")?;
+    let client = client_for(global)?;
+
+    let artifact = client
+        .get_artifact()
+        .id(artifact_id)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to get artifact: {e}")))?
+        .into_inner();
+
+    let info = serde_json::json!({
+        "id": artifact.id.to_string(),
+        "path": artifact.path,
+        "name": artifact.name,
+        "version": artifact.version,
+        "size": format_bytes(artifact.size_bytes),
+        "size_bytes": artifact.size_bytes,
+        "content_type": artifact.content_type,
+        "sha256": artifact.checksum_sha256,
+        "downloads": artifact.download_count,
+        "repository": artifact.repository_key,
+        "created_at": artifact.created_at.to_rfc3339(),
+    });
+
+    let table_str = format!(
+        "ID:           {}\n\
+         Path:         {}\n\
+         Name:         {}\n\
+         Version:      {}\n\
+         Size:         {}\n\
+         Content Type: {}\n\
+         SHA-256:      {}\n\
+         Downloads:    {}\n\
+         Repository:   {}\n\
+         Created:      {}",
+        artifact.id,
+        artifact.path,
+        artifact.name,
+        artifact.version.as_deref().unwrap_or("-"),
+        format_bytes(artifact.size_bytes),
+        artifact.content_type,
+        artifact.checksum_sha256,
+        artifact.download_count,
+        artifact.repository_key,
+        artifact.created_at.format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn show_metadata(id: &str, global: &GlobalArgs) -> Result<()> {
+    let artifact_id = parse_uuid(id, "artifact")?;
+    let client = client_for(global)?;
+
+    let meta = client
+        .get_artifact_metadata()
+        .id(artifact_id)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to get artifact metadata: {e}")))?
+        .into_inner();
+
+    let info = serde_json::json!({
+        "artifact_id": meta.artifact_id.to_string(),
+        "format": meta.format,
+        "metadata": meta.metadata,
+        "properties": meta.properties,
+    });
+
+    let table_str = format!(
+        "Artifact:   {}\n\
+         Format:     {}\n\
+         Metadata:   {}\n\
+         Properties: {}",
+        meta.artifact_id,
+        meta.format,
+        serde_json::to_string(&meta.metadata).unwrap_or_else(|_| "-".to_string()),
+        serde_json::to_string(&meta.properties).unwrap_or_else(|_| "-".to_string()),
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn show_stats(id: &str, global: &GlobalArgs) -> Result<()> {
+    let artifact_id = parse_uuid(id, "artifact")?;
+    let client = client_for(global)?;
+
+    let stats = client
+        .get_artifact_stats()
+        .id(artifact_id)
+        .send()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Failed to get artifact stats: {e}")))?
+        .into_inner();
+
+    let info = serde_json::json!({
+        "artifact_id": stats.artifact_id.to_string(),
+        "download_count": stats.download_count,
+        "first_downloaded": stats.first_downloaded.map(|t| t.to_rfc3339()),
+        "last_downloaded": stats.last_downloaded.map(|t| t.to_rfc3339()),
+    });
+
+    let fmt_dt = |dt: Option<chrono::DateTime<chrono::Utc>>| {
+        dt.map(|t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+            .unwrap_or_else(|| "-".to_string())
+    };
+
+    let table_str = format!(
+        "Artifact:        {}\n\
+         Downloads:       {}\n\
+         First Download:  {}\n\
+         Last Download:   {}",
+        stats.artifact_id,
+        stats.download_count,
+        fmt_dt(stats.first_downloaded),
+        fmt_dt(stats.last_downloaded),
     );
 
     println!("{}", output::render(&info, &global.format, Some(table_str)));
@@ -1129,6 +1281,43 @@ mod tests {
         assert!(try_parse(&["test", "info"]).is_err());
     }
 
+    // ---- Show/Metadata/Stats (by-id) subcommand parsing ----
+
+    #[test]
+    fn parse_show_by_id() {
+        let cli = parse(&["test", "show", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]);
+        if let ArtifactCommand::Show { id } = cli.command {
+            assert_eq!(id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        } else {
+            panic!("Expected ArtifactCommand::Show");
+        }
+    }
+
+    #[test]
+    fn parse_show_by_id_missing_id_fails() {
+        assert!(try_parse(&["test", "show"]).is_err());
+    }
+
+    #[test]
+    fn parse_metadata_by_id() {
+        let cli = parse(&["test", "metadata", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]);
+        if let ArtifactCommand::Metadata { id } = cli.command {
+            assert_eq!(id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        } else {
+            panic!("Expected ArtifactCommand::Metadata");
+        }
+    }
+
+    #[test]
+    fn parse_stats_by_id() {
+        let cli = parse(&["test", "stats", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]);
+        if let ArtifactCommand::Stats { id } = cli.command {
+            assert_eq!(id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        } else {
+            panic!("Expected ArtifactCommand::Stats");
+        }
+    }
+
     // ---- Delete subcommand parsing ----
 
     #[test]
@@ -1565,6 +1754,79 @@ mod tests {
         let global = crate::test_utils::test_global(OutputFormat::Json);
         let result = info("my-repo", "nonexistent", &global).await;
         assert!(result.is_err());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_show_by_id() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/api/v1/artifacts/[^/]+$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "00000000-0000-0000-0000-000000000001",
+                "path": "org/example/lib/1.0/lib-1.0.jar",
+                "name": "lib",
+                "version": "1.0",
+                "size_bytes": 2621440_i64,
+                "content_type": "application/java-archive",
+                "checksum_sha256": "abc123def456",
+                "analyzable": true,
+                "download_count": 150_i64,
+                "repository_key": "maven-central",
+                "created_at": "2026-01-15T10:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = show_by_id("00000000-0000-0000-0000-000000000001", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_show_metadata() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/api/v1/artifacts/[^/]+/metadata$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "artifact_id": "00000000-0000-0000-0000-000000000001",
+                "format": "maven",
+                "metadata": { "groupId": "org.example" },
+                "properties": { "build": "42" }
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = show_metadata("00000000-0000-0000-0000-000000000001", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_show_stats() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/api/v1/artifacts/[^/]+/stats$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "artifact_id": "00000000-0000-0000-0000-000000000001",
+                "download_count": 150_i64,
+                "first_downloaded": "2026-01-10T10:00:00Z",
+                "last_downloaded": "2026-01-15T10:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = show_stats("00000000-0000-0000-0000-000000000001", &global).await;
+        assert!(result.is_ok());
         crate::test_utils::teardown_env();
     }
 

--- a/src/commands/dt.rs
+++ b/src/commands/dt.rs
@@ -75,6 +75,16 @@ pub enum DtProjectCommand {
         uuid: String,
     },
 
+    /// Fetch the raw findings projection for a project (GET .../projects/{uuid})
+    ///
+    /// Note: the backend's `get_project` route returns the project's
+    /// Dependency-Track *findings*, not project metadata — use `show` for
+    /// metadata. Provided for parity with the API operation.
+    Get {
+        /// Project UUID
+        uuid: String,
+    },
+
     /// List findings (vulnerabilities) for a project
     Findings {
         /// Project UUID
@@ -145,6 +155,7 @@ impl DtProjectCommand {
         match self {
             Self::List => project_list(global).await,
             Self::Show { uuid } => project_show(&uuid, global).await,
+            Self::Get { uuid } => project_get(&uuid, global).await,
             Self::Components { uuid } => project_components(&uuid, global).await,
             Self::Findings { uuid, severity } => {
                 project_findings(&uuid, severity.as_deref(), global).await
@@ -381,6 +392,45 @@ async fn project_findings(
     );
 
     eprintln!("{} finding(s).", findings_count);
+
+    Ok(())
+}
+
+async fn project_get(uuid: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = crate::output::spinner("Fetching project findings...");
+
+    let findings = client
+        .get_project()
+        .project_uuid(uuid)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get project", e))?;
+
+    spinner.finish_and_clear();
+
+    let findings = findings.into_inner();
+
+    if findings.is_empty() {
+        eprintln!("No findings found.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for f in &findings {
+            println!("{}", f.vulnerability.vuln_id);
+        }
+        return Ok(());
+    }
+
+    let (entries, table_str) = format_findings_table(&findings);
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    eprintln!("{} finding(s).", findings.len());
 
     Ok(())
 }
@@ -1103,6 +1153,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_project_get() {
+        let cli = parse(&["test", "project", "get", "proj-uuid-123"]);
+        if let DtCommand::Project(DtProjectCommand::Get { uuid }) = cli.command {
+            assert_eq!(uuid, "proj-uuid-123");
+        } else {
+            panic!("Expected Project Get");
+        }
+    }
+
+    #[test]
     fn parse_project_components() {
         let cli = parse(&["test", "project", "components", "proj-uuid"]);
         if let DtCommand::Project(DtProjectCommand::Components { uuid }) = cli.command {
@@ -1733,6 +1793,62 @@ mod tests {
 
         let global = crate::test_utils::test_global(OutputFormat::Json);
         let result = project_findings("some-uuid", None, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_project_get_empty() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/api/v1/dependency-track/projects/[^/]+$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = project_get("some-uuid", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_project_get_with_data() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"/api/v1/dependency-track/projects/[^/]+$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "vulnerability": {
+                        "uuid": "vuln-uuid-1",
+                        "vulnId": "CVE-2024-1234",
+                        "severity": "CRITICAL",
+                        "source": "NVD",
+                        "title": "Test vuln",
+                        "cvssV3BaseScore": 9.8,
+                        "cwe": null,
+                        "description": null
+                    },
+                    "component": {
+                        "uuid": "comp-uuid-1",
+                        "name": "lodash",
+                        "version": "4.17.20",
+                        "group": null,
+                        "purl": null
+                    },
+                    "analysis": null,
+                    "attribution": null
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = project_get("some-uuid", &global).await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
     }

--- a/src/commands/sbom.rs
+++ b/src/commands/sbom.rs
@@ -121,6 +121,42 @@ pub enum SbomCveCommand {
         #[arg(long)]
         reason: Option<String>,
     },
+
+    /// Show CVE history for one artifact (typed UUID route)
+    ///
+    /// Canonical replacement for the artifact branch of the overloaded
+    /// `history <id>` route. Takes a strict artifact UUID.
+    HistoryByArtifact {
+        /// Artifact UUID
+        artifact_id: String,
+    },
+
+    /// Show CVE history for a single CVE across all accessible artifacts
+    HistoryByCve {
+        /// CVE identifier (e.g. CVE-2019-10744)
+        cve_id: String,
+    },
+
+    /// Update CVE status by (artifact, CVE) pair for scan-derived rows
+    ///
+    /// Targets the stable (artifact_id, cve_id) identity of a Security-tab
+    /// row instead of a `cve_history` primary key, so synthesized findings
+    /// (which have no `cve_history` row) can be acknowledged.
+    UpdateStatusByArtifactCve {
+        /// Artifact UUID
+        artifact_id: String,
+
+        /// CVE identifier (e.g. CVE-2019-10744)
+        cve_id: String,
+
+        /// New status (open, fixed, acknowledged, false_positive)
+        #[arg(long)]
+        status: String,
+
+        /// Reason for the status change
+        #[arg(long)]
+        reason: Option<String>,
+    },
 }
 
 impl SbomCommand {
@@ -168,6 +204,25 @@ impl SbomCveCommand {
                 status,
                 reason,
             } => cve_update_status(&cve_id, &status, reason.as_deref(), global).await,
+            Self::HistoryByArtifact { artifact_id } => {
+                cve_history_by_artifact(&artifact_id, global).await
+            }
+            Self::HistoryByCve { cve_id } => cve_history_by_cve(&cve_id, global).await,
+            Self::UpdateStatusByArtifactCve {
+                artifact_id,
+                cve_id,
+                status,
+                reason,
+            } => {
+                cve_update_status_by_artifact_cve(
+                    &artifact_id,
+                    &cve_id,
+                    &status,
+                    reason.as_deref(),
+                    global,
+                )
+                .await
+            }
         }
     }
 }
@@ -557,26 +612,69 @@ async fn cve_history(artifact_id: &str, global: &GlobalArgs) -> Result<()> {
     let entries = resp.into_inner();
     spinner.finish_and_clear();
 
+    render_cve_history(&entries, global);
+    Ok(())
+}
+
+async fn cve_history_by_artifact(artifact_id: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let aid = parse_uuid(artifact_id, "artifact")?;
+
+    let spinner = output::spinner("Fetching CVE history...");
+
+    let resp = client
+        .get_cve_history_by_artifact()
+        .artifact_id(aid)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get CVE history by artifact", e))?;
+
+    let entries = resp.into_inner();
+    spinner.finish_and_clear();
+
+    render_cve_history(&entries, global);
+    Ok(())
+}
+
+async fn cve_history_by_cve(cve_id: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+
+    let spinner = output::spinner("Fetching CVE history...");
+
+    let resp = client
+        .get_cve_history_by_cve()
+        .cve_id(cve_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get CVE history by CVE", e))?;
+
+    let entries = resp.into_inner();
+    spinner.finish_and_clear();
+
+    render_cve_history(&entries, global);
+    Ok(())
+}
+
+/// Render a list of CVE history entries honoring the output format.
+fn render_cve_history(entries: &[CveHistoryEntry], global: &GlobalArgs) {
     if entries.is_empty() {
         eprintln!("No CVE history found.");
-        return Ok(());
+        return;
     }
 
     if matches!(global.format, OutputFormat::Quiet) {
-        for e in &entries {
+        for e in entries {
             println!("{}", e.cve_id);
         }
-        return Ok(());
+        return;
     }
 
-    let (json_entries, table_str) = format_cve_history_table(&entries);
+    let (json_entries, table_str) = format_cve_history_table(entries);
 
     println!(
         "{}",
         output::render(&json_entries, &global.format, Some(table_str))
     );
-
-    Ok(())
 }
 
 async fn cve_trends(days: i32, repo: Option<&str>, global: &GlobalArgs) -> Result<()> {
@@ -673,9 +771,48 @@ async fn cve_update_status(
     let entry = resp.into_inner();
     spinner.finish_and_clear();
 
+    render_updated_cve(&entry, global);
+    Ok(())
+}
+
+async fn cve_update_status_by_artifact_cve(
+    artifact_id: &str,
+    cve_id: &str,
+    status: &str,
+    reason: Option<&str>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for(global)?;
+    let aid = parse_uuid(artifact_id, "artifact")?;
+
+    let spinner = output::spinner("Updating CVE status...");
+
+    let body = artifact_keeper_sdk::types::UpdateCveStatusRequest {
+        status: status.to_string(),
+        reason: reason.map(|s| s.to_string()),
+    };
+
+    let resp = client
+        .update_cve_status_by_artifact_cve()
+        .artifact_id(aid)
+        .cve_id(cve_id)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("update CVE status by artifact/CVE", e))?;
+
+    let entry = resp.into_inner();
+    spinner.finish_and_clear();
+
+    render_updated_cve(&entry, global);
+    Ok(())
+}
+
+/// Render the result of a CVE status update honoring the output format.
+fn render_updated_cve(entry: &CveHistoryEntry, global: &GlobalArgs) {
     if matches!(global.format, OutputFormat::Quiet) {
         println!("{}", entry.id);
-        return Ok(());
+        return;
     }
 
     let info = serde_json::json!({
@@ -704,8 +841,6 @@ async fn cve_update_status(
     );
 
     println!("{}", output::render(&info, &global.format, Some(table_str)));
-
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -1145,6 +1280,67 @@ mod tests {
     #[test]
     fn parse_cve_update_status_missing_status() {
         let result = try_parse(&["test", "cve", "update-status", "cve-id-123"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_cve_history_by_artifact() {
+        let cli = parse(&["test", "cve", "history-by-artifact", "artifact-uuid"]);
+        if let SbomCommand::Cve(SbomCveCommand::HistoryByArtifact { artifact_id }) = cli.command {
+            assert_eq!(artifact_id, "artifact-uuid");
+        } else {
+            panic!("Expected Cve HistoryByArtifact");
+        }
+    }
+
+    #[test]
+    fn parse_cve_history_by_cve() {
+        let cli = parse(&["test", "cve", "history-by-cve", "CVE-2019-10744"]);
+        if let SbomCommand::Cve(SbomCveCommand::HistoryByCve { cve_id }) = cli.command {
+            assert_eq!(cve_id, "CVE-2019-10744");
+        } else {
+            panic!("Expected Cve HistoryByCve");
+        }
+    }
+
+    #[test]
+    fn parse_cve_update_status_by_artifact_cve() {
+        let cli = parse(&[
+            "test",
+            "cve",
+            "update-status-by-artifact-cve",
+            "artifact-uuid",
+            "CVE-2019-10744",
+            "--status",
+            "acknowledged",
+            "--reason",
+            "not exploitable",
+        ]);
+        if let SbomCommand::Cve(SbomCveCommand::UpdateStatusByArtifactCve {
+            artifact_id,
+            cve_id,
+            status,
+            reason,
+        }) = cli.command
+        {
+            assert_eq!(artifact_id, "artifact-uuid");
+            assert_eq!(cve_id, "CVE-2019-10744");
+            assert_eq!(status, "acknowledged");
+            assert_eq!(reason.as_deref(), Some("not exploitable"));
+        } else {
+            panic!("Expected Cve UpdateStatusByArtifactCve");
+        }
+    }
+
+    #[test]
+    fn parse_cve_update_status_by_artifact_cve_missing_status() {
+        let result = try_parse(&[
+            "test",
+            "cve",
+            "update-status-by-artifact-cve",
+            "artifact-uuid",
+            "CVE-2019-10744",
+        ]);
         assert!(result.is_err());
     }
 
@@ -1799,6 +1995,99 @@ mod tests {
 
         let global = crate::test_utils::test_global(OutputFormat::Quiet);
         let result = cve_update_status(NIL_UUID, "false_positive", None, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    fn cve_entry_json(cve_id: &str, status: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": NIL_UUID,
+            "artifact_id": NIL_UUID,
+            "cve_id": cve_id,
+            "severity": "HIGH",
+            "affected_component": "lodash",
+            "status": status,
+            "cvss_score": 8.5,
+            "first_detected_at": "2024-02-21T00:00:00Z",
+            "last_detected_at": "2024-02-21T00:00:00Z",
+            "created_at": "2024-02-21T00:00:00Z",
+            "updated_at": "2024-02-21T12:00:00Z",
+            "acknowledged_at": null,
+            "acknowledged_by": null,
+            "acknowledged_reason": null,
+            "affected_version": null,
+            "component_id": null,
+            "cve_published_at": null,
+            "fixed_version": null,
+            "sbom_id": null,
+            "scan_result_id": null
+        })
+    }
+
+    #[tokio::test]
+    async fn handler_cve_history_by_artifact() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex("/api/v1/sbom/cve/history/by-artifact/.+"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!([cve_entry_json("CVE-2024-1234", "open")])),
+            )
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = cve_history_by_artifact(NIL_UUID, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_cve_history_by_cve() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex("/api/v1/sbom/cve/history/by-cve/.+"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                cve_entry_json("CVE-2019-10744", "open")
+            ])))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = cve_history_by_cve("CVE-2019-10744", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_cve_update_status_by_artifact_cve() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path_regex(
+                "/api/v1/sbom/cve/status/by-artifact/.+/by-cve/.+",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(cve_entry_json("CVE-2019-10744", "acknowledged")),
+            )
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = cve_update_status_by_artifact_cve(
+            NIL_UUID,
+            "CVE-2019-10744",
+            "acknowledged",
+            Some("not exploitable"),
+            &global,
+        )
+        .await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
     }

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -1,4 +1,4 @@
-use artifact_keeper_sdk::types::{DashboardResponse, PolicyResponse, ScoreResponse};
+use artifact_keeper_sdk::types::{DashboardResponse, PolicyResponse, ScanResponse, ScoreResponse};
 use artifact_keeper_sdk::{ClientRepositoriesExt, ClientSecurityExt};
 use clap::Subcommand;
 use console::style;
@@ -52,6 +52,24 @@ pub enum ScanCommand {
 
         /// Results per page
         #[arg(long, default_value = "50")]
+        per_page: i64,
+    },
+
+    /// List scans for a specific artifact (by global artifact ID)
+    Artifact {
+        /// Artifact ID
+        artifact_id: String,
+
+        /// Filter by scan status
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Page number
+        #[arg(long, default_value = "1")]
+        page: i64,
+
+        /// Results per page
+        #[arg(long, default_value = "20")]
         per_page: i64,
     },
 
@@ -231,6 +249,12 @@ impl ScanCommand {
                 page,
                 per_page,
             } => show_findings(&id, severity.as_deref(), page, per_page, global).await,
+            Self::Artifact {
+                artifact_id,
+                status,
+                page,
+                per_page,
+            } => list_artifact_scans(&artifact_id, status.as_deref(), page, per_page, global).await,
             Self::Dashboard => show_dashboard(global).await,
             Self::Scores => show_scores(global).await,
             Self::Config { command } => match command {
@@ -410,8 +434,73 @@ async fn list_scans(
         return Ok(());
     }
 
-    let entries: Vec<_> = resp
-        .items
+    let (entries, table_str) = format_scans_table(&resp.items);
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    eprintln!("{} scans total.", resp.total);
+
+    Ok(())
+}
+
+async fn list_artifact_scans(
+    artifact_id: &str,
+    status: Option<&str>,
+    page: i64,
+    per_page: i64,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let client = client_for(global)?;
+    let aid = parse_uuid(artifact_id, "artifact")?;
+
+    let spinner = crate::output::spinner("Fetching artifact scans...");
+
+    let mut req = client
+        .list_artifact_scans()
+        .artifact_id(aid)
+        .page(page)
+        .per_page(per_page);
+    if let Some(s) = status {
+        req = req.status(s);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| sdk_err("list artifact scans", e))?;
+
+    spinner.finish_and_clear();
+
+    if resp.items.is_empty() {
+        eprintln!("No scans found for artifact.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for scan in &resp.items {
+            println!("{}", scan.id);
+        }
+        return Ok(());
+    }
+
+    let (entries, table_str) = format_scans_table(&resp.items);
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    eprintln!("{} scans total.", resp.total);
+
+    Ok(())
+}
+
+/// Build the JSON entries and rendered table for a list of scans.
+fn format_scans_table(items: &[ScanResponse]) -> (Vec<Value>, String) {
+    let entries: Vec<_> = items
         .iter()
         .map(|s| {
             serde_json::json!({
@@ -429,40 +518,29 @@ async fn list_scans(
         })
         .collect();
 
-    let table_str = {
-        let mut table = new_table(vec![
-            "ID", "STATUS", "TYPE", "FINDINGS", "C", "H", "M", "L", "ARTIFACT", "CREATED",
+    let mut table = new_table(vec![
+        "ID", "STATUS", "TYPE", "FINDINGS", "C", "H", "M", "L", "ARTIFACT", "CREATED",
+    ]);
+
+    for s in items {
+        let id_short = short_id(&s.id);
+        let artifact = s.artifact_name.as_deref().unwrap_or("-");
+        let created = s.created_at.format("%Y-%m-%d %H:%M").to_string();
+        table.add_row(vec![
+            &id_short,
+            &s.status,
+            &s.scan_type,
+            &s.findings_count.to_string(),
+            &format_severity_count(s.critical_count, "CRITICAL"),
+            &format_severity_count(s.high_count, "HIGH"),
+            &format_severity_count(s.medium_count, "MEDIUM"),
+            &format_severity_count(s.low_count, "LOW"),
+            artifact,
+            &created,
         ]);
+    }
 
-        for s in &resp.items {
-            let id_short = short_id(&s.id);
-            let artifact = s.artifact_name.as_deref().unwrap_or("-");
-            let created = s.created_at.format("%Y-%m-%d %H:%M").to_string();
-            table.add_row(vec![
-                &id_short,
-                &s.status,
-                &s.scan_type,
-                &s.findings_count.to_string(),
-                &format_severity_count(s.critical_count, "CRITICAL"),
-                &format_severity_count(s.high_count, "HIGH"),
-                &format_severity_count(s.medium_count, "MEDIUM"),
-                &format_severity_count(s.low_count, "LOW"),
-                artifact,
-                &created,
-            ]);
-        }
-
-        table.to_string()
-    };
-
-    println!(
-        "{}",
-        output::render(&entries, &global.format, Some(table_str))
-    );
-
-    eprintln!("{} scans total.", resp.total);
-
-    Ok(())
+    (entries, table.to_string())
 }
 
 async fn show_findings(
@@ -1469,6 +1547,51 @@ mod tests {
     }
 
     #[test]
+    fn parse_scan_artifact_defaults() {
+        let cli = parse_scan(&["test", "artifact", "art-uuid-123"]);
+        if let ScanCommand::Artifact {
+            artifact_id,
+            status,
+            page,
+            per_page,
+        } = cli.command
+        {
+            assert_eq!(artifact_id, "art-uuid-123");
+            assert!(status.is_none());
+            assert_eq!(page, 1);
+            assert_eq!(per_page, 20);
+        } else {
+            panic!("Expected Artifact");
+        }
+    }
+
+    #[test]
+    fn parse_scan_artifact_with_status() {
+        let cli = parse_scan(&[
+            "test",
+            "artifact",
+            "art-uuid-123",
+            "--status",
+            "completed",
+            "--page",
+            "2",
+        ]);
+        if let ScanCommand::Artifact {
+            artifact_id,
+            status,
+            page,
+            ..
+        } = cli.command
+        {
+            assert_eq!(artifact_id, "art-uuid-123");
+            assert_eq!(status.as_deref(), Some("completed"));
+            assert_eq!(page, 2);
+        } else {
+            panic!("Expected Artifact");
+        }
+    }
+
+    #[test]
     fn parse_list_with_options() {
         let cli = parse_scan(&[
             "test",
@@ -2255,6 +2378,70 @@ mod tests {
 
         let global = crate::test_utils::test_global(OutputFormat::Quiet);
         let result = list_scans(Some("my-repo"), 1, 20, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_list_artifact_scans_empty() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex("/api/v1/security/artifacts/.+/scans"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [],
+                "total": 0_i64
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result =
+            list_artifact_scans("00000000-0000-0000-0000-000000000099", None, 1, 20, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_list_artifact_scans_with_data() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex("/api/v1/security/artifacts/.+/scans"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [{
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "artifact_id": "00000000-0000-0000-0000-000000000099",
+                    "repository_id": "00000000-0000-0000-0000-000000000002",
+                    "status": "completed",
+                    "scan_type": "trivy",
+                    "findings_count": 3,
+                    "critical_count": 1,
+                    "high_count": 1,
+                    "medium_count": 1,
+                    "low_count": 0,
+                    "info_count": 0,
+                    "is_reused": false,
+                    "artifact_name": "pkg.jar",
+                    "artifact_version": "1.0",
+                    "created_at": "2026-01-15T10:00:00Z"
+                }],
+                "total": 1_i64
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = list_artifact_scans(
+            "00000000-0000-0000-0000-000000000099",
+            Some("completed"),
+            1,
+            20,
+            &global,
+        )
+        .await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
     }

--- a/src/commands/webhook.rs
+++ b/src/commands/webhook.rs
@@ -82,6 +82,16 @@ pub enum WebhookCommand {
         id: String,
     },
 
+    /// Rotate a webhook's signing secret
+    ///
+    /// Generates a new signing secret and returns it once. The previous
+    /// secret stays valid for a short window so consumers can roll over
+    /// without dropping deliveries.
+    RotateSecret {
+        /// Webhook ID
+        id: String,
+    },
+
     /// List deliveries for a webhook
     Deliveries {
         /// Webhook ID
@@ -128,6 +138,7 @@ impl WebhookCommand {
             Self::Test { id } => test_webhook(&id, global).await,
             Self::Enable { id } => enable_webhook(&id, global).await,
             Self::Disable { id } => disable_webhook(&id, global).await,
+            Self::RotateSecret { id } => rotate_webhook_secret(&id, global).await,
             Self::Deliveries { id, status } => {
                 list_deliveries(&id, status.as_deref(), global).await
             }
@@ -352,6 +363,52 @@ async fn disable_webhook(id: &str, global: &GlobalArgs) -> Result<()> {
         &format!("Webhook {id} disabled."),
         global,
     );
+
+    Ok(())
+}
+
+async fn rotate_webhook_secret(id: &str, global: &GlobalArgs) -> Result<()> {
+    let webhook_id = parse_uuid(id, "webhook")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Rotating webhook secret...");
+
+    let resp = client
+        .rotate_webhook_secret()
+        .id(webhook_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("rotate webhook secret", e))?;
+
+    let resp = resp.into_inner();
+    spinner.finish_and_clear();
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        println!("{}", resp.secret);
+        return Ok(());
+    }
+
+    let info = serde_json::json!({
+        "id": resp.id.to_string(),
+        "secret": resp.secret,
+        "secret_digest": resp.secret_digest,
+        "previous_secret_expires_at": resp.previous_secret_expires_at.to_rfc3339(),
+    });
+
+    let table_str = format!(
+        "Webhook secret rotated. Store the new secret now — it is shown only once.\n\n\
+         Webhook:              {}\n\
+         New Secret:           {}\n\
+         Secret Digest:        {}\n\
+         Previous Secret Until: {}",
+        resp.id,
+        resp.secret,
+        resp.secret_digest,
+        resp.previous_secret_expires_at
+            .format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
 
     Ok(())
 }
@@ -879,6 +936,22 @@ mod tests {
     #[test]
     fn parse_disable_missing_id() {
         let result = try_parse(&["test", "disable"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_rotate_secret() {
+        let cli = parse(&["test", "rotate-secret", "webhook-id"]);
+        if let WebhookCommand::RotateSecret { id } = cli.command {
+            assert_eq!(id, "webhook-id");
+        } else {
+            panic!("Expected RotateSecret");
+        }
+    }
+
+    #[test]
+    fn parse_rotate_secret_missing_id() {
+        let result = try_parse(&["test", "rotate-secret"]);
         assert!(result.is_err());
     }
 
@@ -1471,6 +1544,50 @@ mod tests {
 
         let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
         let result = enable_webhook(NIL_UUID, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_rotate_webhook_secret() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path(format!("/api/v1/webhooks/{NIL_UUID}/rotate-secret")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": NIL_UUID,
+                "secret": "rotated-dummy-secret-value",
+                "secret_digest": "sha256:abcd",
+                "previous_secret_expires_at": "2026-01-16T12:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = rotate_webhook_secret(NIL_UUID, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_rotate_webhook_secret_quiet() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path(format!("/api/v1/webhooks/{NIL_UUID}/rotate-secret")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": NIL_UUID,
+                "secret": "rotated-dummy-secret-value",
+                "secret_digest": "sha256:abcd",
+                "previous_secret_expires_at": "2026-01-16T12:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = rotate_webhook_secret(NIL_UUID, &global).await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
     }


### PR DESCRIPTION
## Summary

Wires ten previously-unwired SDK operations across the security / supply-chain command groups into their existing command modules. Each op follows the established module conventions (`client_for` / `output::spinner` / `sdk_err` / `output::render`) and extends the module’s own subcommand enum — no new top-level `cli.rs` variants.

## Operations wired

| Domain | SDK operation | Command | Endpoint |
|---|---|---|---|
| sbom | `get_cve_history_by_artifact` | `ak sbom cve history-by-artifact <artifact_id>` | `GET /api/v1/sbom/cve/history/by-artifact/{artifact_id}` |
| sbom | `get_cve_history_by_cve` | `ak sbom cve history-by-cve <cve_id>` | `GET /api/v1/sbom/cve/history/by-cve/{cve_id}` |
| sbom | `update_cve_status_by_artifact_cve` | `ak sbom cve update-status-by-artifact-cve <artifact_id> <cve_id> --status` | `POST /api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id}` |
| dt | `get_project` | `ak dt project get <uuid>` | `GET /api/v1/dependency-track/projects/{project_uuid}` |
| security | `list_artifact_scans` | `ak scan artifact <artifact_id>` | `GET /api/v1/security/artifacts/{artifact_id}/scans` |
| webhooks | `rotate_webhook_secret` | `ak webhook rotate-secret <id>` | `POST /api/v1/webhooks/{id}/rotate-secret` |
| approval | `request_approval` | `ak approval request <artifact_id> --source --target` | `POST /api/v1/approval/request` |
| artifacts | `get_artifact` | `ak artifact show <id>` | `GET /api/v1/artifacts/{id}` |
| artifacts | `get_artifact_metadata` | `ak artifact metadata <id>` | `GET /api/v1/artifacts/{id}/metadata` |
| artifacts | `get_artifact_stats` | `ak artifact stats <id>` | `GET /api/v1/artifacts/{id}/stats` |

Notes:
- `ak sbom cve` previously only exposed the legacy overloaded `history/{id}` and `status/{id}` routes; these add the canonical typed split routes.
- `ak dt project get` returns the backend’s findings projection for a project (the `get_project` route returns findings, not project metadata — `ak dt project show` remains the way to view metadata); documented on the subcommand.
- Shared table/render logic factored into helpers (`format_scans_table`, `render_cve_history`, `render_updated_cve`) so the new handlers reuse existing formatting.

## Test Checklist

- [x] `cargo build --workspace` / `cargo build --release`
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` (1756 passing; added parse + wiremock handler tests for every new subcommand)
- [x] `cargo clippy` — new code is clippy-clean
- [x] Smoke-tested against a live v1.4.0 backend: `approval request`, `artifact stats`, `sbom cve history-by-cve`, `scan artifact` verified end-to-end; `artifact metadata` / `history-by-artifact` correctly surface backend 404s; `webhook rotate-secret` requires `AK_WEBHOOK_SECRET_KEY` configured server-side; `dt project get` depends on a configured Dependency-Track backend.

## API notes

`GET /api/v1/artifacts/{id}` (`get_artifact`): the live backend response omits fields the OpenAPI `ArtifactResponse` schema marks **required** (`analyzable`, `download_count`) and returns extra DB-row fields (`repository_id`, `checksum_md5`, `checksum_sha1`, `updated_at`), so the generated SDK fails to deserialize a real response. The command is wired correctly per the spec; the server/spec mismatch should be reconciled separately.

Closes #121