### PR TITLE
feat: wire remaining admin/user/lifecycle CLI operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Artifact Keeper CLI (`ak`) will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `ak group update <id> <name> [--description]` to rename/redescribe a group
+- `ak permission show <id>` and `ak permission update <id>` for reading and replacing permission rules
+- `ak label repo set <key> <labels...>` to replace all labels on a repository in one call
+- `ak lifecycle update <id>` (change name/enabled/priority/description/config/cron) and `ak lifecycle execute-all` to run every enabled policy
+- `ak admin telemetry crash <id>` and `ak admin telemetry delete-crash <id>` for single crash-report inspection and removal
+- `ak email-subscriptions` (alias `email-subs`) command group: `list`, `subscribe`, and `unsubscribe` for repository email notifications
+
 ## [1.0.0] - 2026-02-23
 
 ### Stable Release

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -357,6 +357,16 @@ pub enum Command {
         #[command(subcommand)]
         command: commands::age_gate::AgeGateCommand,
     },
+    /// Manage repository email subscriptions (event notifications)
+    #[command(
+        name = "email-subscriptions",
+        visible_alias = "email-subs",
+        after_help = "Examples:\n  ak email-subscriptions list my-repo\n  ak email-subs subscribe my-repo --recipients ops@example.com --events artifact.uploaded,scan.completed\n  ak email-subscriptions unsubscribe my-repo <subscription-id>"
+    )]
+    EmailSubscriptions {
+        #[command(subcommand)]
+        command: commands::email_subscriptions::EmailSubscriptionsCommand,
+    },
     /// Manage repository-scoped access tokens
     #[command(
         after_help = "Examples:\n  ak repo-token list my-repo\n  ak repo-token create my-repo ci-token --scopes read,write\n  ak repo-token show my-repo <token-id>\n  ak repo-token revoke my-repo <token-id>"
@@ -506,6 +516,7 @@ impl Cli {
             Command::Completion { shell } => commands::completion::execute(shell),
             Command::ManPages { dir } => commands::completion::generate_man_pages(&dir),
             Command::AgeGate { command } => command.execute(&global).await,
+            Command::EmailSubscriptions { command } => command.execute(&global).await,
             Command::RepoToken { command } => command.execute(&global).await,
             Command::Builds { command } => command.execute(&global).await,
             Command::ServiceAccount { command } => command.execute(&global).await,
@@ -529,6 +540,28 @@ mod tests {
     }
 
     // ---- Basic command parsing ----
+
+    #[test]
+    fn parse_email_subscriptions_list() {
+        let cli = parse(&["ak", "email-subscriptions", "list", "my-repo"]).unwrap();
+        assert!(matches!(cli.command, Command::EmailSubscriptions { .. }));
+    }
+
+    #[test]
+    fn parse_email_subscriptions_alias() {
+        let cli = parse(&[
+            "ak",
+            "email-subs",
+            "subscribe",
+            "my-repo",
+            "--recipients",
+            "ops@example.com",
+            "--events",
+            "artifact.uploaded",
+        ])
+        .unwrap();
+        assert!(matches!(cli.command, Command::EmailSubscriptions { .. }));
+    }
 
     #[test]
     fn parse_auth_login() {

--- a/src/commands/admin.rs
+++ b/src/commands/admin.rs
@@ -393,6 +393,20 @@ pub enum TelemetryCommand {
         /// Crash report IDs (comma-separated)
         ids: String,
     },
+    /// Show a single crash report
+    Crash {
+        /// Crash report ID
+        id: String,
+    },
+    /// Delete a crash report
+    DeleteCrash {
+        /// Crash report ID
+        id: String,
+
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -775,6 +789,8 @@ impl AdminCommand {
                     per_page,
                 } => list_crashes(pending, page, per_page, global).await,
                 TelemetryCommand::Submit { ids } => submit_crashes(&ids, global).await,
+                TelemetryCommand::Crash { id } => get_crash(&id, global).await,
+                TelemetryCommand::DeleteCrash { id, yes } => delete_crash(&id, yes, global).await,
             },
             Self::CiOidc { command } => match command {
                 CiOidcCommand::List => list_ci_oidc_providers(global).await,
@@ -2257,6 +2273,85 @@ fn crash_report_json(c: &artifact_keeper_sdk::types::CrashReport) -> serde_json:
         "created_at": c.created_at.to_rfc3339(),
         "last_seen_at": c.last_seen_at.to_rfc3339(),
     })
+}
+
+async fn get_crash(id: &str, global: &GlobalArgs) -> Result<()> {
+    let crash_id = parse_uuid(id, "crash report")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching crash report...");
+
+    let crash = client
+        .get_crash()
+        .id(crash_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get crash report", e))?;
+
+    spinner.finish_and_clear();
+
+    let info = crash_report_json(&crash);
+
+    let table_str = format!(
+        "ID:             {}\n\
+         Severity:       {}\n\
+         Error Type:     {}\n\
+         Error Message:  {}\n\
+         Component:      {}\n\
+         App Version:    {}\n\
+         Occurrences:    {}\n\
+         Submitted:      {}\n\
+         Created:        {}\n\
+         First Seen:     {}\n\
+         Last Seen:      {}",
+        crash.id,
+        crash.severity,
+        crash.error_type,
+        crash.error_message,
+        crash.component,
+        crash.app_version,
+        crash.occurrence_count,
+        if crash.submitted { "yes" } else { "no" },
+        crash.created_at.format("%Y-%m-%d %H:%M:%S UTC"),
+        crash.first_seen_at.format("%Y-%m-%d %H:%M:%S UTC"),
+        crash.last_seen_at.format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+async fn delete_crash(id: &str, skip_confirm: bool, global: &GlobalArgs) -> Result<()> {
+    let crash_id = parse_uuid(id, "crash report")?;
+
+    if !confirm_action(
+        &format!("Delete crash report {id}?"),
+        skip_confirm,
+        global.no_input,
+    )? {
+        return Ok(());
+    }
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Deleting crash report...");
+
+    client
+        .delete_crash()
+        .id(crash_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("delete crash report", e))?;
+
+    spinner.finish_and_clear();
+    emit_mutation(
+        &serde_json::json!({ "id": id, "status": "deleted" }),
+        id,
+        &format!("Crash report {id} deleted."),
+        global,
+    );
+
+    Ok(())
 }
 
 fn format_telemetry_settings(s: &artifact_keeper_sdk::types::TelemetrySettings) -> String {
@@ -4354,6 +4449,54 @@ mod tests {
         assert!(try_parse(&["test", "telemetry"]).is_err());
     }
 
+    #[test]
+    fn parse_telemetry_crash() {
+        let cli = parse(&[
+            "test",
+            "telemetry",
+            "crash",
+            "00000000-0000-0000-0000-000000000001",
+        ]);
+        if let AdminCommand::Telemetry {
+            command: TelemetryCommand::Crash { id },
+        } = cli.command
+        {
+            assert_eq!(id, "00000000-0000-0000-0000-000000000001");
+        } else {
+            panic!("Expected TelemetryCommand::Crash");
+        }
+    }
+
+    #[test]
+    fn parse_telemetry_crash_missing_id_fails() {
+        assert!(try_parse(&["test", "telemetry", "crash"]).is_err());
+    }
+
+    #[test]
+    fn parse_telemetry_delete_crash() {
+        let cli = parse(&[
+            "test",
+            "telemetry",
+            "delete-crash",
+            "00000000-0000-0000-0000-000000000001",
+            "--yes",
+        ]);
+        if let AdminCommand::Telemetry {
+            command: TelemetryCommand::DeleteCrash { id, yes },
+        } = cli.command
+        {
+            assert_eq!(id, "00000000-0000-0000-0000-000000000001");
+            assert!(yes);
+        } else {
+            panic!("Expected TelemetryCommand::DeleteCrash");
+        }
+    }
+
+    #[test]
+    fn parse_telemetry_delete_crash_missing_id_fails() {
+        assert!(try_parse(&["test", "telemetry", "delete-crash"]).is_err());
+    }
+
     // ---- Missing subcommand fails ----
 
     #[test]
@@ -5907,6 +6050,72 @@ mod tests {
         } else {
             panic!("Expected ProxyCommand::Post");
         }
+    }
+
+    #[tokio::test]
+    async fn handler_get_crash() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/admin/telemetry/crashes/00000000-0000-0000-0000-000000000001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "00000000-0000-0000-0000-000000000001",
+                "severity": "critical",
+                "error_type": "panic",
+                "error_message": "index out of bounds",
+                "error_signature": "abc123",
+                "component": "storage",
+                "app_version": "1.0.0",
+                "occurrence_count": 5,
+                "submitted": false,
+                "context": {},
+                "created_at": "2026-01-15T10:00:00Z",
+                "first_seen_at": "2026-01-15T10:00:00Z",
+                "last_seen_at": "2026-01-15T12:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = get_crash("00000000-0000-0000-0000-000000000001", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_get_crash_invalid_id() {
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = get_crash("not-a-uuid", &global).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn handler_delete_crash() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/api/v1/admin/telemetry/crashes/00000000-0000-0000-0000-000000000001",
+            ))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = delete_crash("00000000-0000-0000-0000-000000000001", true, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_delete_crash_invalid_id() {
+        let global = crate::test_utils::test_global(OutputFormat::Json);
+        let result = delete_crash("not-a-uuid", true, &global).await;
+        assert!(result.is_err());
     }
 
     // ---- insta snapshot tests ----

--- a/src/commands/email_subscriptions.rs
+++ b/src/commands/email_subscriptions.rs
@@ -1,0 +1,536 @@
+use artifact_keeper_sdk::ClientEmailSubscriptionsExt;
+use clap::Subcommand;
+use miette::Result;
+
+use super::client::{client_for, resolve_base_url_and_auth};
+use super::helpers::{confirm_action, emit_mutation, new_table, parse_uuid, sdk_err, short_id};
+use crate::cli::GlobalArgs;
+use crate::error::AkError;
+use crate::output::{self, OutputFormat};
+
+#[derive(Subcommand)]
+pub enum EmailSubscriptionsCommand {
+    /// List the email subscriptions configured on a repository
+    List {
+        /// Repository key
+        repo: String,
+    },
+
+    /// Subscribe recipients to repository events
+    Subscribe {
+        /// Repository key
+        repo: String,
+
+        /// Recipient email addresses (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        recipients: Vec<String>,
+
+        /// Event types to subscribe to (comma-separated, e.g.
+        /// artifact.uploaded, scan.completed, vulnerability.detected)
+        #[arg(long, value_delimiter = ',')]
+        events: Vec<String>,
+
+        /// Create the subscription in a disabled state
+        #[arg(long)]
+        disabled: bool,
+    },
+
+    /// Remove an email subscription by id
+    Unsubscribe {
+        /// Repository key
+        repo: String,
+
+        /// Subscription ID
+        id: String,
+
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+impl EmailSubscriptionsCommand {
+    pub async fn execute(self, global: &GlobalArgs) -> Result<()> {
+        match self {
+            Self::List { repo } => list_subscriptions(&repo, global).await,
+            Self::Subscribe {
+                repo,
+                recipients,
+                events,
+                disabled,
+            } => subscribe(&repo, recipients, events, disabled, global).await,
+            Self::Unsubscribe { repo, id, yes } => unsubscribe(&repo, &id, yes, global).await,
+        }
+    }
+}
+
+fn subscription_json(
+    s: &artifact_keeper_sdk::types::EmailSubscriptionResponse,
+) -> serde_json::Value {
+    serde_json::json!({
+        "id": s.id.to_string(),
+        "repository_id": s.repository_id.map(|u| u.to_string()),
+        "enabled": s.enabled,
+        "event_types": s.event_types,
+        "recipients": s.recipients,
+        "created_at": s.created_at.to_rfc3339(),
+        "updated_at": s.updated_at.to_rfc3339(),
+    })
+}
+
+async fn list_subscriptions(repo: &str, global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching email subscriptions...");
+
+    let resp = client
+        .list_subscriptions()
+        .key(repo)
+        .send()
+        .await
+        .map_err(|e| sdk_err("list email subscriptions", e))?;
+
+    spinner.finish_and_clear();
+
+    if resp.subscriptions.is_empty() {
+        eprintln!("No email subscriptions on repository '{repo}'.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Quiet) {
+        for s in &resp.subscriptions {
+            println!("{}", s.id);
+        }
+        return Ok(());
+    }
+
+    let entries: Vec<_> = resp.subscriptions.iter().map(subscription_json).collect();
+
+    let table_str = {
+        let mut table = new_table(vec!["ID", "ENABLED", "EVENTS", "RECIPIENTS"]);
+
+        for s in &resp.subscriptions {
+            let id_short = short_id(&s.id);
+            let enabled = if s.enabled { "yes" } else { "no" };
+            let events = s.event_types.join(", ");
+            let recipients = s.recipients.join(", ");
+            table.add_row(vec![&id_short, enabled, &events, &recipients]);
+        }
+
+        table.to_string()
+    };
+
+    println!(
+        "{}",
+        output::render(&entries, &global.format, Some(table_str))
+    );
+
+    Ok(())
+}
+
+async fn subscribe(
+    repo: &str,
+    recipients: Vec<String>,
+    events: Vec<String>,
+    disabled: bool,
+    global: &GlobalArgs,
+) -> Result<()> {
+    if recipients.is_empty() {
+        return Err(AkError::ConfigError(
+            "At least one --recipients address is required.".to_string(),
+        )
+        .into());
+    }
+    if events.is_empty() {
+        return Err(
+            AkError::ConfigError("At least one --events type is required.".to_string()).into(),
+        );
+    }
+
+    // NOTE: the SDK's `create_subscription` only accepts an HTTP 201 response,
+    // but the live backend returns 200 for this endpoint (spec drift). Build the
+    // request directly so any 2xx is treated as success.
+    let body = serde_json::json!({
+        "event_types": events,
+        "recipients": recipients,
+        "enabled": !disabled,
+    });
+
+    let (base_url, auth_header) = resolve_base_url_and_auth(global)?;
+    let spinner = output::spinner("Creating email subscription...");
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .post(format!(
+            "{}/api/v1/repositories/{repo}/email-subscriptions",
+            base_url.trim_end_matches('/')
+        ))
+        .header(reqwest::header::AUTHORIZATION, auth_header)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("create email subscription", e))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| sdk_err("create email subscription", e))?;
+
+    spinner.finish_and_clear();
+
+    if !status.is_success() {
+        let msg = serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| {
+                v.get("message")
+                    .and_then(|m| m.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or(text);
+        return Err(AkError::ServerError(format!(
+            "create email subscription failed (HTTP {}): {msg}",
+            status.as_u16()
+        ))
+        .into());
+    }
+
+    let sub: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| sdk_err("parse email subscription response", e))?;
+    let id = sub["id"].as_str().unwrap_or_default().to_string();
+    let recipient_count = sub["recipients"].as_array().map(|a| a.len()).unwrap_or(0);
+    let event_count = sub["event_types"].as_array().map(|a| a.len()).unwrap_or(0);
+
+    emit_mutation(
+        &sub,
+        &id,
+        &format!(
+            "Subscribed {recipient_count} recipient(s) to {event_count} event(s) on '{repo}' (ID: {id})."
+        ),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn unsubscribe(repo: &str, id: &str, skip_confirm: bool, global: &GlobalArgs) -> Result<()> {
+    let sub_id = parse_uuid(id, "subscription")?;
+
+    if !confirm_action(
+        &format!("Remove email subscription {id} from '{repo}'?"),
+        skip_confirm,
+        global.no_input,
+    )? {
+        return Ok(());
+    }
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Removing email subscription...");
+
+    client
+        .delete_subscription()
+        .key(repo)
+        .subscription_id(sub_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("delete email subscription", e))?;
+
+    spinner.finish_and_clear();
+    emit_mutation(
+        &serde_json::json!({ "repo_key": repo, "id": id, "status": "removed" }),
+        id,
+        &format!("Email subscription {id} removed from '{repo}'."),
+        global,
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use serde_json::json;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: EmailSubscriptionsCommand,
+    }
+
+    fn parse(args: &[&str]) -> TestCli {
+        TestCli::try_parse_from(args).unwrap()
+    }
+
+    fn try_parse(args: &[&str]) -> Result<TestCli, clap::Error> {
+        TestCli::try_parse_from(args)
+    }
+
+    // ---- parsing: list ----
+
+    #[test]
+    fn parse_list() {
+        let cli = parse(&["test", "list", "npm-local"]);
+        match cli.command {
+            EmailSubscriptionsCommand::List { repo } => assert_eq!(repo, "npm-local"),
+            _ => panic!("expected List"),
+        }
+    }
+
+    #[test]
+    fn parse_list_missing_repo() {
+        assert!(try_parse(&["test", "list"]).is_err());
+    }
+
+    // ---- parsing: subscribe ----
+
+    #[test]
+    fn parse_subscribe() {
+        let cli = parse(&[
+            "test",
+            "subscribe",
+            "npm-local",
+            "--recipients",
+            "ops@example.com,dev@example.com",
+            "--events",
+            "artifact.uploaded,scan.completed",
+        ]);
+        match cli.command {
+            EmailSubscriptionsCommand::Subscribe {
+                repo,
+                recipients,
+                events,
+                disabled,
+            } => {
+                assert_eq!(repo, "npm-local");
+                assert_eq!(recipients, vec!["ops@example.com", "dev@example.com"]);
+                assert_eq!(events, vec!["artifact.uploaded", "scan.completed"]);
+                assert!(!disabled);
+            }
+            _ => panic!("expected Subscribe"),
+        }
+    }
+
+    #[test]
+    fn parse_subscribe_disabled() {
+        let cli = parse(&[
+            "test",
+            "subscribe",
+            "npm-local",
+            "--recipients",
+            "ops@example.com",
+            "--events",
+            "scan.failed",
+            "--disabled",
+        ]);
+        match cli.command {
+            EmailSubscriptionsCommand::Subscribe { disabled, .. } => assert!(disabled),
+            _ => panic!("expected Subscribe"),
+        }
+    }
+
+    #[test]
+    fn parse_subscribe_missing_repo() {
+        assert!(try_parse(&["test", "subscribe", "--recipients", "a@b.com"]).is_err());
+    }
+
+    // ---- parsing: unsubscribe ----
+
+    #[test]
+    fn parse_unsubscribe() {
+        let cli = parse(&[
+            "test",
+            "unsubscribe",
+            "npm-local",
+            "00000000-0000-0000-0000-000000000001",
+            "--yes",
+        ]);
+        match cli.command {
+            EmailSubscriptionsCommand::Unsubscribe { repo, id, yes } => {
+                assert_eq!(repo, "npm-local");
+                assert_eq!(id, "00000000-0000-0000-0000-000000000001");
+                assert!(yes);
+            }
+            _ => panic!("expected Unsubscribe"),
+        }
+    }
+
+    #[test]
+    fn parse_unsubscribe_missing_id() {
+        assert!(try_parse(&["test", "unsubscribe", "npm-local"]).is_err());
+    }
+
+    // ---- format function ----
+
+    #[test]
+    fn subscription_json_fields() {
+        let s = artifact_keeper_sdk::types::EmailSubscriptionResponse {
+            id: uuid::Uuid::nil(),
+            repository_id: Some(uuid::Uuid::nil()),
+            enabled: true,
+            event_types: vec!["artifact.uploaded".to_string()],
+            recipients: vec!["ops@example.com".to_string()],
+            created_at: "2026-01-15T12:00:00Z".parse().unwrap(),
+            updated_at: "2026-01-15T12:00:00Z".parse().unwrap(),
+        };
+        let v = subscription_json(&s);
+        assert_eq!(v["enabled"], json!(true));
+        assert_eq!(v["recipients"][0], json!("ops@example.com"));
+        assert_eq!(v["event_types"][0], json!("artifact.uploaded"));
+    }
+
+    // ---- wiremock handler tests ----
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    static NIL_UUID: &str = "00000000-0000-0000-0000-000000000000";
+
+    fn subscription_body() -> serde_json::Value {
+        json!({
+            "id": NIL_UUID,
+            "repository_id": NIL_UUID,
+            "recipients": ["ops@example.com"],
+            "event_types": ["artifact.uploaded"],
+            "enabled": true,
+            "created_at": "2026-01-15T12:00:00Z",
+            "updated_at": "2026-01-15T12:00:00Z"
+        })
+    }
+
+    #[tokio::test]
+    async fn handler_list_subscriptions_empty() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repositories/npm-local/email-subscriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "subscriptions": [] })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = list_subscriptions("npm-local", &global).await;
+        assert!(result.is_ok(), "list failed: {:?}", result.err());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_list_subscriptions_with_data() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repositories/npm-local/email-subscriptions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "subscriptions": [subscription_body()] })),
+            )
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Table);
+        let result = list_subscriptions("npm-local", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_list_subscriptions_quiet() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repositories/npm-local/email-subscriptions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "subscriptions": [subscription_body()] })),
+            )
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = list_subscriptions("npm-local", &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_subscribe() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        // The live backend returns 200 (not the spec's 201); the raw-request
+        // path must accept any 2xx.
+        Mock::given(method("POST"))
+            .and(path("/api/v1/repositories/npm-local/email-subscriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(subscription_body()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = subscribe(
+            "npm-local",
+            vec!["ops@example.com".to_string()],
+            vec!["artifact.uploaded".to_string()],
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok(), "subscribe failed: {:?}", result.err());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_subscribe_no_recipients() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = subscribe(
+            "npm-local",
+            vec![],
+            vec!["artifact.uploaded".to_string()],
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn handler_subscribe_no_events() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = subscribe(
+            "npm-local",
+            vec!["ops@example.com".to_string()],
+            vec![],
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn handler_unsubscribe() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("DELETE"))
+            .and(path(format!(
+                "/api/v1/repositories/npm-local/email-subscriptions/{NIL_UUID}"
+            )))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = unsubscribe("npm-local", NIL_UUID, true, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_unsubscribe_invalid_id() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = unsubscribe("npm-local", "not-a-uuid", true, &global).await;
+        assert!(result.is_err());
+    }
+}

--- a/src/commands/group.rs
+++ b/src/commands/group.rs
@@ -42,6 +42,19 @@ pub enum GroupCommand {
         description: Option<String>,
     },
 
+    /// Update a group's name and/or description
+    Update {
+        /// Group ID
+        id: String,
+
+        /// New group name
+        name: String,
+
+        /// New description
+        #[arg(long)]
+        description: Option<String>,
+    },
+
     /// Delete a group
     Delete {
         /// Group ID
@@ -83,6 +96,11 @@ impl GroupCommand {
             Self::Create { name, description } => {
                 create_group(&name, description.as_deref(), global).await
             }
+            Self::Update {
+                id,
+                name,
+                description,
+            } => update_group(&id, &name, description.as_deref(), global).await,
             Self::Delete { id, yes } => delete_group(&id, yes, global).await,
             Self::AddMember { group, user } => add_member(&group, &user, global).await,
             Self::RemoveMember { group, user } => remove_member(&group, &user, global).await,
@@ -232,6 +250,42 @@ async fn create_group(name: &str, description: Option<&str>, global: &GlobalArgs
         &*group,
         &group.id.to_string(),
         &format!("Group '{}' created (ID: {}).", group.name, group.id),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn update_group(
+    id: &str,
+    name: &str,
+    description: Option<&str>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let group_id = parse_uuid(id, "group")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Updating group...");
+
+    let body = artifact_keeper_sdk::types::CreateGroupRequest {
+        name: name.to_string(),
+        description: description.map(|s| s.to_string()),
+    };
+
+    let group = client
+        .update_group()
+        .id(group_id)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("update group", e))?;
+
+    spinner.finish_and_clear();
+
+    emit_mutation(
+        &*group,
+        &group.id.to_string(),
+        &format!("Group '{}' updated (ID: {}).", group.name, group.id),
         global,
     );
 
@@ -481,6 +535,55 @@ mod tests {
     #[test]
     fn parse_create_missing_name() {
         let result = try_parse(&["test", "create"]);
+        assert!(result.is_err());
+    }
+
+    // ---- parsing: update ----
+
+    #[test]
+    fn parse_update_minimal() {
+        let cli = parse(&["test", "update", "group-id", "new-name"]);
+        match cli.command {
+            GroupCommand::Update {
+                id,
+                name,
+                description,
+            } => {
+                assert_eq!(id, "group-id");
+                assert_eq!(name, "new-name");
+                assert!(description.is_none());
+            }
+            _ => panic!("expected Update"),
+        }
+    }
+
+    #[test]
+    fn parse_update_with_description() {
+        let cli = parse(&[
+            "test",
+            "update",
+            "group-id",
+            "new-name",
+            "--description",
+            "Updated team",
+        ]);
+        match cli.command {
+            GroupCommand::Update {
+                id,
+                name,
+                description,
+            } => {
+                assert_eq!(id, "group-id");
+                assert_eq!(name, "new-name");
+                assert_eq!(description.as_deref(), Some("Updated team"));
+            }
+            _ => panic!("expected Update"),
+        }
+    }
+
+    #[test]
+    fn parse_update_missing_name() {
+        let result = try_parse(&["test", "update", "group-id"]);
         assert!(result.is_err());
     }
 
@@ -764,6 +867,47 @@ mod tests {
         let result = create_group("developers", Some("Core dev team"), &global).await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_update_group_quiet() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path(format!("/api/v1/groups/{NIL_UUID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(group_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = update_group(NIL_UUID, "developers", Some("Core dev team"), &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_update_group_json() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path(format!("/api/v1/groups/{NIL_UUID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(group_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = update_group(NIL_UUID, "developers", None, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_update_group_invalid_id() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = update_group("not-a-uuid", "name", None, &global).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -48,6 +48,15 @@ pub enum RepoLabelCommand {
         /// Label key to remove
         label_key: String,
     },
+
+    /// Set (replace) all labels on a repository
+    Set {
+        /// Repository key
+        key: String,
+
+        /// Labels in key=value format (value optional); replaces all existing labels
+        labels: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -95,6 +104,7 @@ impl LabelCommand {
                 RepoLabelCommand::Remove { key, label_key } => {
                     remove_label(&key, &label_key, global).await
                 }
+                RepoLabelCommand::Set { key, labels } => set_labels(&key, &labels, global).await,
             },
             Self::Artifact { command } => match command {
                 ArtifactLabelCommand::List { id } => list_artifact_labels(&id, global).await,
@@ -241,6 +251,65 @@ async fn remove_label(repo_key: &str, label_key: &str, global: &GlobalArgs) -> R
         }),
         repo_key,
         &format!("Label '{label_key}' removed from repository '{repo_key}'."),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn set_labels(repo_key: &str, labels: &[String], global: &GlobalArgs) -> Result<()> {
+    let entries: Vec<artifact_keeper_sdk::types::LabelEntrySchema> = labels
+        .iter()
+        .map(|l| match l.split_once('=') {
+            Some((k, v)) => artifact_keeper_sdk::types::LabelEntrySchema {
+                key: k.to_string(),
+                value: Some(v.to_string()),
+            },
+            None => artifact_keeper_sdk::types::LabelEntrySchema {
+                key: l.to_string(),
+                value: None,
+            },
+        })
+        .collect();
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Setting labels...");
+
+    let body = artifact_keeper_sdk::types::SetLabelsRequest { labels: entries };
+
+    let resp = client
+        .set_repo_labels()
+        .key(repo_key)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("set labels", e))?;
+
+    spinner.finish_and_clear();
+
+    let result: Vec<_> = resp
+        .items
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "key": l.key,
+                "value": l.value,
+            })
+        })
+        .collect();
+
+    emit_mutation(
+        &serde_json::json!({
+            "repo_key": repo_key,
+            "count": resp.items.len(),
+            "labels": result,
+            "status": "set",
+        }),
+        repo_key,
+        &format!(
+            "Set {} label(s) on repository '{repo_key}'.",
+            resp.items.len()
+        ),
         global,
     );
 
@@ -513,6 +582,44 @@ mod tests {
     fn parse_repo_remove_missing_label_key() {
         let result = try_parse(&["test", "repo", "remove", "maven-releases"]);
         assert!(result.is_err());
+    }
+
+    // ---- parsing: repo set ----
+
+    #[test]
+    fn parse_repo_set() {
+        let cli = parse(&[
+            "test",
+            "repo",
+            "set",
+            "maven-releases",
+            "env=production",
+            "team=platform",
+        ]);
+        match cli.command {
+            LabelCommand::Repo {
+                command: RepoLabelCommand::Set { key, labels },
+            } => {
+                assert_eq!(key, "maven-releases");
+                assert_eq!(labels, vec!["env=production", "team=platform"]);
+            }
+            _ => panic!("expected Repo Set"),
+        }
+    }
+
+    #[test]
+    fn parse_repo_set_empty_labels() {
+        // `set` with zero labels is allowed (clears all labels)
+        let cli = parse(&["test", "repo", "set", "maven-releases"]);
+        match cli.command {
+            LabelCommand::Repo {
+                command: RepoLabelCommand::Set { key, labels },
+            } => {
+                assert_eq!(key, "maven-releases");
+                assert!(labels.is_empty());
+            }
+            _ => panic!("expected Repo Set"),
+        }
     }
 
     // ---- parsing: missing nested subcommand ----
@@ -804,6 +911,27 @@ mod tests {
         let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
         let result = remove_label("npm-local", "env", &global).await;
         assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_set_labels() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/repositories/npm-local/labels"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "items": [label_json()],
+                "total": 1_u64
+            })))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let labels = vec!["env=production".to_string(), "team".to_string()];
+        let result = set_labels("npm-local", &labels, &global).await;
+        assert!(result.is_ok(), "set failed: {:?}", result.err());
         crate::test_utils::teardown_env();
     }
 

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -61,6 +61,40 @@ pub enum LifecycleCommand {
         cron_schedule: Option<String>,
     },
 
+    /// Update a lifecycle policy (only provided fields are changed)
+    Update {
+        /// Policy ID
+        id: String,
+
+        /// New policy name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Enable the policy
+        #[arg(long, conflicts_with = "disabled")]
+        enabled: bool,
+
+        /// Disable the policy
+        #[arg(long, conflicts_with = "enabled")]
+        disabled: bool,
+
+        /// New priority (higher priority policies run first)
+        #[arg(long)]
+        priority: Option<i32>,
+
+        /// New description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// New policy configuration as a JSON object (see `create` for shape)
+        #[arg(long)]
+        config: Option<String>,
+
+        /// New cron schedule for automatic execution (e.g. "0 2 * * *")
+        #[arg(long)]
+        cron_schedule: Option<String>,
+    },
+
     /// Delete a lifecycle policy
     Delete {
         /// Policy ID
@@ -70,6 +104,9 @@ pub enum LifecycleCommand {
         #[arg(long)]
         yes: bool,
     },
+
+    /// Execute all enabled policies now
+    ExecuteAll,
 
     /// Preview what a policy would affect (dry-run)
     Preview {
@@ -110,7 +147,31 @@ impl LifecycleCommand {
                 )
                 .await
             }
+            Self::Update {
+                id,
+                name,
+                enabled,
+                disabled,
+                priority,
+                description,
+                config,
+                cron_schedule,
+            } => {
+                update_policy(
+                    &id,
+                    name.as_deref(),
+                    enabled,
+                    disabled,
+                    priority,
+                    description.as_deref(),
+                    config.as_deref(),
+                    cron_schedule.as_deref(),
+                    global,
+                )
+                .await
+            }
             Self::Delete { id, yes } => delete_policy(&id, yes, global).await,
+            Self::ExecuteAll => execute_all_policies(global).await,
             Self::Preview { id } => preview_policy(&id, global).await,
             Self::Execute { id } => execute_policy(&id, global).await,
         }
@@ -373,6 +434,159 @@ async fn create_policy(
         &format!("Lifecycle policy '{pname}' created (ID: {id})."),
         global,
     );
+
+    Ok(())
+}
+
+// The lifecycle PATCH endpoint (`/api/v1/admin/lifecycle/:id`) is documented in
+// the OpenAPI spec as taking `UpdatePolicyRequest`, but that schema is a
+// quality-gate shape whose fields (is_enabled, max_artifact_age_days, ...) are
+// ignored by this endpoint. The endpoint actually accepts the lifecycle-policy
+// fields (name/enabled/priority/description/config/cron_schedule), so — as with
+// `create_policy` — build the request body directly rather than via the SDK.
+#[allow(clippy::too_many_arguments)]
+async fn update_policy(
+    id: &str,
+    name: Option<&str>,
+    enabled: bool,
+    disabled: bool,
+    priority: Option<i32>,
+    description: Option<&str>,
+    config: Option<&str>,
+    cron_schedule: Option<&str>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    parse_uuid(id, "policy")?;
+
+    let mut body = serde_json::Map::new();
+    if let Some(n) = name {
+        body.insert("name".to_string(), serde_json::Value::from(n));
+    }
+    // `--enabled` / `--disabled` are mutually exclusive (enforced by clap); only
+    // send the field when one was explicitly given.
+    if enabled {
+        body.insert("enabled".to_string(), serde_json::Value::from(true));
+    } else if disabled {
+        body.insert("enabled".to_string(), serde_json::Value::from(false));
+    }
+    if let Some(p) = priority {
+        body.insert("priority".to_string(), serde_json::Value::from(p));
+    }
+    if let Some(d) = description {
+        body.insert("description".to_string(), serde_json::Value::from(d));
+    }
+    if let Some(c) = config {
+        let config_json: serde_json::Value = serde_json::from_str(c)
+            .map_err(|e| AkError::ConfigError(format!("--config must be a JSON object: {e}")))?;
+        if !config_json.is_object() {
+            return Err(AkError::ConfigError("--config must be a JSON object".into()).into());
+        }
+        body.insert("config".to_string(), config_json);
+    }
+    if let Some(cs) = cron_schedule {
+        body.insert("cron_schedule".to_string(), serde_json::Value::from(cs));
+    }
+
+    if body.is_empty() {
+        return Err(AkError::ConfigError(
+            "No fields to update; provide at least one of --name/--enabled/--disabled/--priority/--description/--config/--cron-schedule".into(),
+        )
+        .into());
+    }
+
+    let (base_url, auth_header) = resolve_base_url_and_auth(global)?;
+    let spinner = output::spinner("Updating lifecycle policy...");
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .patch(format!(
+            "{}/api/v1/admin/lifecycle/{id}",
+            base_url.trim_end_matches('/')
+        ))
+        .header(reqwest::header::AUTHORIZATION, auth_header)
+        .json(&serde_json::Value::Object(body))
+        .send()
+        .await
+        .map_err(|e| sdk_err("update lifecycle policy", e))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| sdk_err("update lifecycle policy", e))?;
+
+    spinner.finish_and_clear();
+
+    if !status.is_success() {
+        let msg = serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| {
+                v.get("message")
+                    .and_then(|m| m.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or(text);
+        return Err(AkError::ServerError(format!(
+            "update lifecycle policy failed (HTTP {}): {msg}",
+            status.as_u16()
+        ))
+        .into());
+    }
+
+    let policy: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| sdk_err("parse lifecycle policy response", e))?;
+    let pname = policy["name"].as_str().unwrap_or("");
+
+    emit_mutation(
+        &policy,
+        id,
+        &format!("Lifecycle policy '{pname}' updated (ID: {id})."),
+        global,
+    );
+
+    Ok(())
+}
+
+async fn execute_all_policies(global: &GlobalArgs) -> Result<()> {
+    let client = client_for(global)?;
+    let spinner = output::spinner("Executing all policies...");
+
+    let results = client
+        .execute_all_policies()
+        .send()
+        .await
+        .map_err(|e| sdk_err("execute all policies", e))?
+        .into_inner();
+
+    spinner.finish_and_clear();
+
+    if results.is_empty() {
+        eprintln!("No policies were executed.");
+        return Ok(());
+    }
+
+    if matches!(global.format, OutputFormat::Table) {
+        eprintln!("Executed {} policy/policies:", results.len());
+        for result in &results {
+            print_execution_result(result, "Execution", global);
+        }
+    } else {
+        let entries: Vec<_> = results
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "policy_id": r.policy_id.to_string(),
+                    "policy_name": r.policy_name,
+                    "dry_run": r.dry_run,
+                    "artifacts_matched": r.artifacts_matched,
+                    "artifacts_removed": r.artifacts_removed,
+                    "bytes_freed": r.bytes_freed,
+                    "errors": r.errors,
+                })
+            })
+            .collect();
+        println!("{}", output::render(&entries, &global.format, None));
+    }
 
     Ok(())
 }
@@ -712,6 +926,96 @@ mod tests {
             "max_age_days",
         ]);
         assert!(result.is_err());
+    }
+
+    // ---- parsing: update ----
+
+    #[test]
+    fn parse_update_name_only() {
+        let cli = parse(&["test", "update", "policy-id", "--name", "renamed"]);
+        match cli.command {
+            LifecycleCommand::Update {
+                id,
+                name,
+                enabled,
+                disabled,
+                priority,
+                description,
+                config,
+                cron_schedule,
+            } => {
+                assert_eq!(id, "policy-id");
+                assert_eq!(name.as_deref(), Some("renamed"));
+                assert!(!enabled);
+                assert!(!disabled);
+                assert!(priority.is_none());
+                assert!(description.is_none());
+                assert!(config.is_none());
+                assert!(cron_schedule.is_none());
+            }
+            _ => panic!("expected Update"),
+        }
+    }
+
+    #[test]
+    fn parse_update_all_fields() {
+        let cli = parse(&[
+            "test",
+            "update",
+            "policy-id",
+            "--name",
+            "renamed",
+            "--disabled",
+            "--priority",
+            "9",
+            "--description",
+            "desc",
+            "--config",
+            "{\"days\": 60}",
+            "--cron-schedule",
+            "0 2 * * *",
+        ]);
+        match cli.command {
+            LifecycleCommand::Update {
+                name,
+                enabled,
+                disabled,
+                priority,
+                description,
+                config,
+                cron_schedule,
+                ..
+            } => {
+                assert_eq!(name.as_deref(), Some("renamed"));
+                assert!(!enabled);
+                assert!(disabled);
+                assert_eq!(priority, Some(9));
+                assert_eq!(description.as_deref(), Some("desc"));
+                assert_eq!(config.as_deref(), Some("{\"days\": 60}"));
+                assert_eq!(cron_schedule.as_deref(), Some("0 2 * * *"));
+            }
+            _ => panic!("expected Update"),
+        }
+    }
+
+    #[test]
+    fn parse_update_enabled_disabled_conflict() {
+        let result = try_parse(&["test", "update", "policy-id", "--enabled", "--disabled"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_update_missing_id() {
+        let result = try_parse(&["test", "update"]);
+        assert!(result.is_err());
+    }
+
+    // ---- parsing: execute-all ----
+
+    #[test]
+    fn parse_execute_all() {
+        let cli = parse(&["test", "execute-all"]);
+        assert!(matches!(cli.command, LifecycleCommand::ExecuteAll));
     }
 
     // ---- parsing: delete ----
@@ -1113,6 +1417,98 @@ mod tests {
 
         let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
         let result = delete_policy(NIL_UUID, true, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_update_policy_quiet() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PATCH"))
+            .and(path(format!("/api/v1/admin/lifecycle/{NIL_UUID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lifecycle_policy_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = update_policy(
+            NIL_UUID,
+            Some("renamed"),
+            false,
+            true,
+            Some(5),
+            None,
+            None,
+            None,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok(), "update failed: {:?}", result.err());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_update_policy_no_fields() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = update_policy(
+            NIL_UUID, None, false, false, None, None, None, None, &global,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn handler_update_policy_invalid_config() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = update_policy(
+            NIL_UUID,
+            None,
+            false,
+            false,
+            None,
+            None,
+            Some("not-json"),
+            None,
+            &global,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn handler_execute_all_policies() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/admin/lifecycle/execute-all"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!([execution_result_json()])),
+            )
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = execute_all_policies(&global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_execute_all_policies_empty() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/admin/lifecycle/execute-all"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Table);
+        let result = execute_all_policies(&global).await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod curation;
 pub mod doctor;
 pub mod dt;
+pub mod email_subscriptions;
 pub mod group;
 pub mod helpers;
 pub mod import;

--- a/src/commands/permission.rs
+++ b/src/commands/permission.rs
@@ -53,6 +53,38 @@ pub enum PermissionCommand {
         actions: Vec<String>,
     },
 
+    /// Show a permission rule
+    Show {
+        /// Permission ID
+        id: String,
+    },
+
+    /// Update a permission rule (replaces all fields)
+    Update {
+        /// Permission ID
+        id: String,
+
+        /// Principal ID (user or group UUID)
+        #[arg(long)]
+        principal: String,
+
+        /// Principal type (user, group)
+        #[arg(long)]
+        principal_type: String,
+
+        /// Target ID (repository or group UUID)
+        #[arg(long)]
+        target: String,
+
+        /// Target type (repository, group)
+        #[arg(long)]
+        target_type: String,
+
+        /// Actions to grant (comma-separated: read, write, admin)
+        #[arg(long, value_delimiter = ',')]
+        actions: Vec<String>,
+    },
+
     /// Delete a permission rule
     Delete {
         /// Permission ID
@@ -99,9 +131,139 @@ impl PermissionCommand {
                 )
                 .await
             }
+            Self::Show { id } => show_permission(&id, global).await,
+            Self::Update {
+                id,
+                principal,
+                principal_type,
+                target,
+                target_type,
+                actions,
+            } => {
+                update_permission(
+                    &id,
+                    &principal,
+                    &principal_type,
+                    &target,
+                    &target_type,
+                    actions,
+                    global,
+                )
+                .await
+            }
             Self::Delete { id, yes } => delete_permission(&id, yes, global).await,
         }
     }
+}
+
+fn permission_json(p: &artifact_keeper_sdk::types::PermissionResponse) -> serde_json::Value {
+    serde_json::json!({
+        "id": p.id.to_string(),
+        "principal_id": p.principal_id.to_string(),
+        "principal_type": p.principal_type,
+        "principal_name": p.principal_name,
+        "target_id": p.target_id.to_string(),
+        "target_type": p.target_type,
+        "target_name": p.target_name,
+        "actions": p.actions,
+        "created_at": p.created_at.to_rfc3339(),
+        "updated_at": p.updated_at.to_rfc3339(),
+    })
+}
+
+async fn show_permission(id: &str, global: &GlobalArgs) -> Result<()> {
+    let perm_id = parse_uuid(id, "permission")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Fetching permission...");
+
+    let perm = client
+        .get_permission()
+        .id(perm_id)
+        .send()
+        .await
+        .map_err(|e| sdk_err("get permission", e))?;
+
+    spinner.finish_and_clear();
+
+    let info = permission_json(&perm);
+
+    let table_str = format!(
+        "ID:            {}\n\
+         Principal:     {} ({})\n\
+         Principal ID:  {}\n\
+         Target:        {} ({})\n\
+         Target ID:     {}\n\
+         Actions:       {}\n\
+         Created:       {}\n\
+         Updated:       {}",
+        perm.id,
+        perm.principal_name.as_deref().unwrap_or("-"),
+        perm.principal_type,
+        perm.principal_id,
+        perm.target_name.as_deref().unwrap_or("-"),
+        perm.target_type,
+        perm.target_id,
+        perm.actions.join(", "),
+        perm.created_at.format("%Y-%m-%d %H:%M:%S UTC"),
+        perm.updated_at.format("%Y-%m-%d %H:%M:%S UTC"),
+    );
+
+    println!("{}", output::render(&info, &global.format, Some(table_str)));
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn update_permission(
+    id: &str,
+    principal: &str,
+    principal_type: &str,
+    target: &str,
+    target_type: &str,
+    actions: Vec<String>,
+    global: &GlobalArgs,
+) -> Result<()> {
+    let perm_id = parse_uuid(id, "permission")?;
+    let principal_id = parse_uuid(principal, "principal")?;
+    let target_id = parse_uuid(target, "target")?;
+
+    let client = client_for(global)?;
+    let spinner = output::spinner("Updating permission...");
+
+    let body = artifact_keeper_sdk::types::CreatePermissionRequest {
+        principal_id,
+        principal_type: principal_type.to_string(),
+        target_id,
+        target_type: target_type.to_string(),
+        actions,
+    };
+
+    let perm = client
+        .update_permission()
+        .id(perm_id)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| sdk_err("update permission", e))?;
+
+    spinner.finish_and_clear();
+
+    emit_mutation(
+        &*perm,
+        &perm.id.to_string(),
+        &format!(
+            "Permission updated (ID: {}): {} {} on {} {}",
+            perm.id,
+            perm.principal_type,
+            perm.principal_name.as_deref().unwrap_or("?"),
+            perm.target_type,
+            perm.target_name.as_deref().unwrap_or("?"),
+        ),
+        global,
+    );
+
+    Ok(())
 }
 
 async fn list_permissions(
@@ -509,6 +671,82 @@ mod tests {
         }
     }
 
+    // ---- parsing: show ----
+
+    #[test]
+    fn parse_show() {
+        let cli = parse(&["test", "show", "00000000-0000-0000-0000-000000000001"]);
+        match cli.command {
+            PermissionCommand::Show { id } => {
+                assert_eq!(id, "00000000-0000-0000-0000-000000000001");
+            }
+            _ => panic!("expected Show"),
+        }
+    }
+
+    #[test]
+    fn parse_show_missing_id() {
+        assert!(try_parse(&["test", "show"]).is_err());
+    }
+
+    // ---- parsing: update ----
+
+    #[test]
+    fn parse_update_all_required() {
+        let cli = parse(&[
+            "test",
+            "update",
+            "00000000-0000-0000-0000-000000000009",
+            "--principal",
+            "00000000-0000-0000-0000-000000000001",
+            "--principal-type",
+            "user",
+            "--target",
+            "00000000-0000-0000-0000-000000000002",
+            "--target-type",
+            "repository",
+            "--actions",
+            "read,write",
+        ]);
+        match cli.command {
+            PermissionCommand::Update {
+                id,
+                principal,
+                principal_type,
+                target,
+                target_type,
+                actions,
+            } => {
+                assert_eq!(id, "00000000-0000-0000-0000-000000000009");
+                assert_eq!(principal, "00000000-0000-0000-0000-000000000001");
+                assert_eq!(principal_type, "user");
+                assert_eq!(target, "00000000-0000-0000-0000-000000000002");
+                assert_eq!(target_type, "repository");
+                assert_eq!(actions, vec!["read", "write"]);
+            }
+            _ => panic!("expected Update"),
+        }
+    }
+
+    #[test]
+    fn parse_update_missing_id() {
+        let result = try_parse(&[
+            "test",
+            "update",
+            "--principal",
+            "id1",
+            "--principal-type",
+            "user",
+            "--target",
+            "id2",
+            "--target-type",
+            "repository",
+            "--actions",
+            "read",
+        ]);
+        assert!(result.is_err());
+    }
+
     // ---- parsing: delete ----
 
     #[test]
@@ -727,6 +965,72 @@ mod tests {
         .await;
         assert!(result.is_ok());
         crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_show_permission() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path(format!("/api/v1/permissions/{NIL_UUID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(perm_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = show_permission(NIL_UUID, &global).await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_show_permission_invalid_id() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Json);
+        let result = show_permission("not-a-uuid", &global).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn handler_update_permission_quiet() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path(format!("/api/v1/permissions/{NIL_UUID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(perm_json()))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = update_permission(
+            NIL_UUID,
+            NIL_UUID,
+            "user",
+            NIL_UUID,
+            "repository",
+            vec!["read".to_string(), "write".to_string()],
+            &global,
+        )
+        .await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_update_permission_invalid_id() {
+        let global = crate::test_utils::test_global(crate::output::OutputFormat::Quiet);
+        let result = update_permission(
+            "not-a-uuid",
+            NIL_UUID,
+            "user",
+            NIL_UUID,
+            "repository",
+            vec!["read".to_string()],
+            &global,
+        )
+        .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fills the remaining CLI coverage gaps in the admin, user-management, and lifecycle domains. Each backend operation below was exposed by the generated SDK but had no `ak` command; this wires them into their existing command modules (plus one new group), following each module's conventions.

| Domain | Command added | Operation |
| --- | --- | --- |
| groups | `ak group update <id> <name> [--description]` | `update_group` |
| repository-labels | `ak label repo set <key> <labels...>` | `set_repo_labels` |
| permissions | `ak permission show <id>` | `get_permission` |
| permissions | `ak permission update <id> ...` | `update_permission` |
| lifecycle | `ak lifecycle update <id> ...` | `update_lifecycle_policy` |
| lifecycle | `ak lifecycle execute-all` | `execute_all_policies` |
| telemetry | `ak admin telemetry crash <id>` | `get_crash` |
| telemetry | `ak admin telemetry delete-crash <id>` | `delete_crash` |
| email-subscriptions | `ak email-subscriptions list/subscribe/unsubscribe` | `list_subscriptions` / `create_subscription` / `delete_subscription` |

`email-subscriptions` (alias `email-subs`) is a new top-level command group; the rest extend existing subcommand enums.

Two endpoints have request/response shapes that don't match their generated SDK models, so — consistent with the existing `lifecycle create` handler — those two paths build the HTTP request directly instead of via the SDK builder:

- **`lifecycle update`**: the spec models the PATCH body as `UpdatePolicyRequest` (a quality-gate schema whose fields are ignored by this endpoint); the endpoint actually accepts the lifecycle-policy fields (`name`/`enabled`/`priority`/`description`/`config`/`cron_schedule`).
- **`email-subscriptions subscribe`**: the SDK's `create_subscription` only accepts an HTTP `201`, but the endpoint returns `200`, so the SDK call fails on an otherwise-successful create. The direct request treats any `2xx` as success.

## Test Checklist

- [x] `cargo build` / `cargo build --release`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A dead_code` (clean)
- [x] `cargo test --workspace` (1780 passed)
- [x] Added parse, handler (wiremock), and error-path tests for every new command
- [x] Manually exercised each command against a live backend

## API Changes

No SDK regeneration. New CLI surface only; no changes to existing command behavior.
