### PR TITLE
feat(ci): add cargo-audit gate and clear outstanding RUSTSEC advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,23 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace -- -D warnings -A dead_code
 
+  # Fails on any RUSTSEC advisory affecting Cargo.lock (vulnerabilities only;
+  # informational warnings such as unmaintained/unsound do not fail the job).
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ak lifecycle update <id>` (change name/enabled/priority/description/config/cron) and `ak lifecycle execute-all` to run every enabled policy
 - `ak admin telemetry crash <id>` and `ak admin telemetry delete-crash <id>` for single crash-report inspection and removal
 - `ak email-subscriptions` (alias `email-subs`) command group: `list`, `subscribe`, and `unsubscribe` for repository email notifications
+- Security Audit CI job (`cargo audit`) so vulnerable dependencies fail pull requests instead of accumulating silently
+
+### Security
+
+- Updated `quinn-proto` to 0.11.15 (RUSTSEC-2026-0185, unbounded out-of-order stream reassembly, high severity)
+- Updated `rustls-webpki` to 0.103.13 (RUSTSEC-2026-0098/0099 name-constraint bypasses, RUSTSEC-2026-0104 CRL-parsing panic)
+- Updated `time` to 0.3.47 (RUSTSEC-2026-0009, stack exhaustion)
+
+### Changed
+
+- Bumped MSRV from 1.86.0 to 1.88.0 (required by `time` 0.3.47)
 
 ## [1.0.0] - 2026-02-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,9 +1823,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2234,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2642,9 +2642,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "libc",
@@ -3252,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/artifact-keeper/artifact-keeper-cli"
 homepage = "https://artifactkeeper.com"
 keywords = ["artifact", "registry", "cli", "package-manager"]
 categories = ["command-line-utilities", "development-tools"]
-rust-version = "1.86.0"
+rust-version = "1.88.0"
 
 [[bin]]
 name = "ak"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ brew install artifact-keeper/tap/ak
 
 ### Cargo (from source)
 
-Requires Rust 1.86+:
+Requires Rust 1.88+:
 
 ```bash
 cargo install artifact-keeper-cli

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -277,16 +277,16 @@ async fn logout(instance: Option<&str>, global: &GlobalArgs) -> Result<()> {
     // Best-effort server-side session invalidation. Never block a local logout
     // on it — if the token is already invalid or the server is unreachable we
     // still want to clear the local credential.
-    if let Ok(cred) = get_credential(&instance_name) {
-        if let Ok(client) = build_client(&instance_name, instance_cfg, Some(&cred)) {
-            let body = artifact_keeper_sdk::types::RefreshTokenRequest {
-                refresh_token: cred.refresh_token.clone(),
-            };
-            if let Err(e) = client.logout().body(body).send().await {
-                eprintln!(
-                    "Warning: server-side logout failed ({e}); clearing local credentials anyway."
-                );
-            }
+    if let Ok(cred) = get_credential(&instance_name)
+        && let Ok(client) = build_client(&instance_name, instance_cfg, Some(&cred))
+    {
+        let body = artifact_keeper_sdk::types::RefreshTokenRequest {
+            refresh_token: cred.refresh_token.clone(),
+        };
+        if let Err(e) = client.logout().body(body).send().await {
+            eprintln!(
+                "Warning: server-side logout failed ({e}); clearing local credentials anyway."
+            );
         }
     }
 

--- a/src/commands/setup/mod.rs
+++ b/src/commands/setup/mod.rs
@@ -171,10 +171,10 @@ fn detect_ecosystems(dir: &Path) -> Vec<&'static str> {
             continue;
         }
         if eco.marker.contains('*') {
-            if let Ok(matches) = glob::glob(&dir.join(eco.marker).to_string_lossy()) {
-                if matches.into_iter().any(|m| m.is_ok()) {
-                    found.push(eco.name);
-                }
+            if let Ok(matches) = glob::glob(&dir.join(eco.marker).to_string_lossy())
+                && matches.into_iter().any(|m| m.is_ok())
+            {
+                found.push(eco.name);
             }
         } else if dir.join(eco.marker).exists() {
             found.push(eco.name);

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -298,11 +298,11 @@ impl App {
 
     /// Get a cached credential, loading from keychain/file only once per instance.
     fn cached_credential(&mut self, instance_name: &str) -> Option<&StoredCredential> {
-        if !self.credential_cache.contains_key(instance_name) {
-            if let Ok(cred) = get_credential(instance_name) {
-                self.credential_cache
-                    .insert(instance_name.to_string(), cred);
-            }
+        if !self.credential_cache.contains_key(instance_name)
+            && let Ok(cred) = get_credential(instance_name)
+        {
+            self.credential_cache
+                .insert(instance_name.to_string(), cred);
         }
         self.credential_cache.get(instance_name)
     }
@@ -1765,33 +1765,33 @@ fn draw_replication_panel(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     // Show selected peer detail below policies
-    if let Some(idx) = app.replication.peer_list_state.selected() {
-        if let Some(peer) = app.replication.peers.get(idx) {
-            lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled("Selected Peer", bold_style())));
-            lines.push(detail_line("  Name:     ", &peer.name));
-            lines.push(detail_line("  Endpoint: ", &peer.endpoint_url));
-            lines.push(detail_line("  Status:   ", &peer.status));
+    if let Some(idx) = app.replication.peer_list_state.selected()
+        && let Some(peer) = app.replication.peers.get(idx)
+    {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("Selected Peer", bold_style())));
+        lines.push(detail_line("  Name:     ", &peer.name));
+        lines.push(detail_line("  Endpoint: ", &peer.endpoint_url));
+        lines.push(detail_line("  Status:   ", &peer.status));
 
-            if let Some(ref region) = peer.region {
-                lines.push(detail_line("  Region:   ", region));
-            }
-            if peer.cache_size_bytes > 0 {
-                lines.push(detail_line(
-                    "  Cache:    ",
-                    &format!(
-                        "{} / {}",
-                        format_bytes(peer.cache_used_bytes),
-                        format_bytes(peer.cache_size_bytes)
-                    ),
-                ));
-            }
-            if let Some(ref ts) = peer.last_sync_at {
-                lines.push(detail_line(
-                    "  Last sync: ",
-                    &ts.format("%Y-%m-%d %H:%M").to_string(),
-                ));
-            }
+        if let Some(ref region) = peer.region {
+            lines.push(detail_line("  Region:   ", region));
+        }
+        if peer.cache_size_bytes > 0 {
+            lines.push(detail_line(
+                "  Cache:    ",
+                &format!(
+                    "{} / {}",
+                    format_bytes(peer.cache_used_bytes),
+                    format_bytes(peer.cache_size_bytes)
+                ),
+            ));
+        }
+        if let Some(ref ts) = peer.last_sync_at {
+            lines.push(detail_line(
+                "  Last sync: ",
+                &ts.format("%Y-%m-%d %H:%M").to_string(),
+            ));
         }
     }
 
@@ -1908,34 +1908,34 @@ fn draw_analytics_panel(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     // Show selected storage entry detail
-    if let Some(idx) = app.analytics.storage_list_state.selected() {
-        if let Some(entry) = app.analytics.storage.get(idx) {
-            lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled(
-                "Selected Repository",
-                bold_style(),
-            )));
-            lines.push(detail_line("  Name:       ", &entry.repository_name));
-            lines.push(detail_line("  Key:        ", &entry.repository_key));
-            lines.push(detail_line("  Format:     ", &entry.format));
+    if let Some(idx) = app.analytics.storage_list_state.selected()
+        && let Some(entry) = app.analytics.storage.get(idx)
+    {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Selected Repository",
+            bold_style(),
+        )));
+        lines.push(detail_line("  Name:       ", &entry.repository_name));
+        lines.push(detail_line("  Key:        ", &entry.repository_key));
+        lines.push(detail_line("  Format:     ", &entry.format));
+        lines.push(detail_line(
+            "  Storage:    ",
+            &format_bytes(entry.storage_bytes),
+        ));
+        lines.push(detail_line(
+            "  Artifacts:  ",
+            &entry.artifact_count.to_string(),
+        ));
+        lines.push(detail_line(
+            "  Downloads:  ",
+            &entry.download_count.to_string(),
+        ));
+        if let Some(ref ts) = entry.last_upload_at {
             lines.push(detail_line(
-                "  Storage:    ",
-                &format_bytes(entry.storage_bytes),
+                "  Last Upload: ",
+                &ts.format("%Y-%m-%d %H:%M").to_string(),
             ));
-            lines.push(detail_line(
-                "  Artifacts:  ",
-                &entry.artifact_count.to_string(),
-            ));
-            lines.push(detail_line(
-                "  Downloads:  ",
-                &entry.download_count.to_string(),
-            ));
-            if let Some(ref ts) = entry.last_upload_at {
-                lines.push(detail_line(
-                    "  Last Upload: ",
-                    &ts.format("%Y-%m-%d %H:%M").to_string(),
-                ));
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

CI runs check/fmt/clippy/test but never `cargo audit`, so vulnerable dependencies are not surfaced during PR review (#74). This adds a **Security Audit** job to `ci.yml` (same pattern as the backend repo: `dtolnay/rust-toolchain@stable` + `taiki-e/install-action` + plain `cargo audit`) that fails on any RUSTSEC vulnerability affecting `Cargo.lock`. Informational warnings (unmaintained/unsound) do not fail the job, so no `audit.toml` ignore list is needed.

To land the gate green, this also clears the advisories `cargo audit` reports against current `main`. Note on #65: the original 8 advisories there (aws-lc-sys 0.37.1 etc.) were already remediated in the lockfile, but three advisories published *after* those pins re-flagged the same crates:

| Crate | Bump | Advisory |
|-------|------|----------|
| quinn-proto | 0.11.14 → 0.11.15 | RUSTSEC-2026-0185 (high, 7.5 — remote memory exhaustion) |
| rustls-webpki | 0.103.10 → 0.103.13 | RUSTSEC-2026-0098/0099 (name-constraint bypass), RUSTSEC-2026-0104 (CRL-parse panic) |
| time | 0.3.45 → 0.3.47 | RUSTSEC-2026-0009 (stack exhaustion) |

`cargo audit` now exits 0 with **zero vulnerabilities** (4 informational warnings only). `aws-lc-sys` is at 0.39.0 with no open advisories — #65 can be closed once this merges, since the audit job then prevents silent regression.

Supporting changes:
- `time` 0.3.47 requires Rust 1.88 → declared MSRV bumped 1.86 → 1.88 (`Cargo.toml`, README). CI builds on `stable`, unaffected. The sdk crate does not depend on `time` and keeps its own MSRV.
- Five nested if-lets collapsed into let-chains (`auth.rs`, `setup/mod.rs`, `tui.rs`) — clippy on current stable (1.97) flags these as `collapsible_if` and would fail the Clippy job for any PR; behavior unchanged.

## Test Checklist

- [x] `cargo audit` → exit 0, 0 vulnerabilities (the exact command the new CI step runs)
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace -- -D warnings -A dead_code` clean on rustc 1.97
- [x] `cargo fmt --check` clean
- [x] `cargo test --workspace` → 2009 passed, 0 failed (451 ignored = e2e, run in the e2e job)
- [x] Workflow YAML validated; existing jobs untouched

## API Changes

None. No behavior changes to the CLI; dependency patch/point bumps and CI only.

Closes #74
