### PR TITLE
fix(cli): artifact push and service-account create fail on success-status mismatch (201/200)

### DIFF
--- a/src/commands/artifact.rs
+++ b/src/commands/artifact.rs
@@ -208,7 +208,7 @@ async fn push(
     no_chunked: bool,
     global: &GlobalArgs,
 ) -> Result<()> {
-    let client = client_for(global)?;
+    let (base_url, auth_header) = super::client::resolve_base_url_and_auth(global)?;
     let chunk_size = super::chunked_upload::parse_size(chunk_size_str)?;
     let threshold = super::chunked_upload::chunked_threshold()?;
 
@@ -261,8 +261,6 @@ async fn push(
 
         if use_chunked {
             // Chunked upload for large files
-            let (base_url, auth_header) = super::client::resolve_base_url_and_auth(global)?;
-
             let result = super::chunked_upload::chunked_upload(
                 &base_url,
                 &auth_header,
@@ -287,7 +285,7 @@ async fn push(
                 );
             }
         } else {
-            // Single PUT for small files (existing behavior)
+            // Single PUT for small files
             let pb = indicatif::ProgressBar::new(file_size);
             pb.set_style(
                 indicatif::ProgressStyle::with_template(
@@ -309,14 +307,8 @@ async fn push(
             });
             let body = reqwest::Body::wrap_stream(stream);
 
-            let resp = client
-                .upload_artifact()
-                .key(repo)
-                .path(&artifact_path)
-                .body(body)
-                .send()
-                .await
-                .map_err(|e| AkError::ServerError(format!("Upload failed: {e}")))?;
+            let resp =
+                single_put_upload(&base_url, &auth_header, repo, &artifact_path, body).await?;
 
             pb.finish_with_message(format!("Uploaded {file_name}"));
 
@@ -339,6 +331,56 @@ async fn push(
     }
 
     Ok(())
+}
+
+/// Response from the single-PUT upload endpoint (the subset of the API's
+/// `ArtifactResponse` that `push` actually uses).
+#[derive(Debug, serde::Deserialize)]
+struct SinglePutUploadResponse {
+    path: String,
+    size_bytes: i64,
+}
+
+/// Upload a small file via a single `PUT` using a raw HTTP request.
+///
+/// The backend responds `201 Created` on this endpoint, but the generated
+/// SDK method (`upload_artifact`) only accepts `200`, so every successful
+/// small-file push was reported as an error even though the artifact was
+/// created (#91, #98). Mirroring `chunked_upload`, this accepts any 2xx
+/// success status and surfaces genuine HTTP errors with status and body.
+async fn single_put_upload(
+    base_url: &str,
+    auth_header: &str,
+    repo: &str,
+    artifact_path: &str,
+    body: reqwest::Body,
+) -> Result<SinglePutUploadResponse> {
+    let mut url = reqwest::Url::parse(base_url)
+        .map_err(|e| AkError::ConfigError(format!("Invalid instance URL {base_url}: {e}")))?;
+    url.path_segments_mut()
+        .map_err(|_| AkError::ConfigError(format!("Invalid instance URL: {base_url}")))?
+        .pop_if_empty()
+        .extend(["api", "v1", "repositories", repo, "artifacts"])
+        .extend(artifact_path.split('/'));
+
+    let resp = reqwest::Client::new()
+        .put(url)
+        .header(reqwest::header::AUTHORIZATION, auth_header)
+        .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| AkError::NetworkError(format!("Upload failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(AkError::ServerError(format!("Upload failed ({status}): {text}")).into());
+    }
+
+    resp.json::<SinglePutUploadResponse>()
+        .await
+        .map_err(|e| AkError::ServerError(format!("Invalid upload response: {e}")).into())
 }
 
 async fn pull(
@@ -2020,5 +2062,158 @@ mod tests {
         ];
         let table = format_search_results_table(&items);
         insta::assert_snapshot!("artifact_search_table", table);
+    }
+
+    // ---- push (single-PUT small-file path) ----
+
+    fn upload_response_json(path: &str, size_bytes: i64) -> serde_json::Value {
+        json!({
+            "id": "00000000-0000-0000-0000-000000000001",
+            "repository_key": "my-repo",
+            "path": path,
+            "name": path,
+            "version": null,
+            "size_bytes": size_bytes,
+            "checksum_sha256": "abc123",
+            "content_type": "application/octet-stream",
+            "download_count": 0_i64,
+            "created_at": "2026-01-15T12:00:00Z",
+            "metadata": null,
+            "analyzable": true
+        })
+    }
+
+    /// The backend returns `201 Created` on the single-PUT upload path;
+    /// a successful small-file push must not be treated as an error (#91).
+    #[tokio::test]
+    async fn handler_push_small_file_accepts_201() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/repositories/my-repo/artifacts/small.bin"))
+            .respond_with(
+                ResponseTemplate::new(201).set_body_json(upload_response_json("small.bin", 9)),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("small.bin");
+        std::fs::write(&file, b"test data").unwrap();
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = push(
+            "my-repo",
+            &[file.to_string_lossy().into_owned()],
+            None,
+            "8MB",
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok(), "201 Created must be a success: {result:?}");
+        crate::test_utils::teardown_env();
+    }
+
+    /// A plain `200 OK` (what the OpenAPI spec declares) must keep working.
+    #[tokio::test]
+    async fn handler_push_small_file_accepts_200() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/repositories/my-repo/artifacts/small.bin"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(upload_response_json("small.bin", 9)),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("small.bin");
+        std::fs::write(&file, b"test data").unwrap();
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = push(
+            "my-repo",
+            &[file.to_string_lossy().into_owned()],
+            None,
+            "8MB",
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    /// A target path with subdirectories must hit the nested artifact route.
+    #[tokio::test]
+    async fn handler_push_small_file_nested_target_path() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path(
+                "/api/v1/repositories/my-repo/artifacts/nested/dir/small.bin",
+            ))
+            .respond_with(
+                ResponseTemplate::new(201)
+                    .set_body_json(upload_response_json("nested/dir/small.bin", 9)),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("small.bin");
+        std::fs::write(&file, b"test data").unwrap();
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = push(
+            "my-repo",
+            &[file.to_string_lossy().into_owned()],
+            Some("nested/dir/"),
+            "8MB",
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    /// Genuine HTTP failures (e.g. unknown repository) must still error.
+    #[tokio::test]
+    async fn handler_push_small_file_404_is_error() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("PUT"))
+            .and(path_regex("^/api/v1/repositories/.+/artifacts/.+$"))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_json(json!({"error": "repository not found"})),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("small.bin");
+        std::fs::write(&file, b"test data").unwrap();
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = push(
+            "no-such-repo",
+            &[file.to_string_lossy().into_owned()],
+            None,
+            "8MB",
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_err(), "404 must remain an error");
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(msg.contains("404"), "error should carry the status: {msg}");
+        crate::test_utils::teardown_env();
     }
 }

--- a/src/commands/service_account.rs
+++ b/src/commands/service_account.rs
@@ -313,8 +313,16 @@ async fn show_account(id: &str, global: &GlobalArgs) -> Result<()> {
     Ok(())
 }
 
+/// Response from service-account creation (the subset of the API's
+/// `ServiceAccountResponse` that `create` actually uses).
+#[derive(Debug, serde::Deserialize)]
+struct CreateAccountResponse {
+    id: String,
+    username: String,
+}
+
 async fn create_account(name: &str, description: Option<&str>, global: &GlobalArgs) -> Result<()> {
-    let client = client_for(global)?;
+    let (base_url, auth_header) = super::client::resolve_base_url_and_auth(global)?;
     let spinner = output::spinner("Creating service account...");
 
     let body = artifact_keeper_sdk::types::CreateServiceAccountRequest {
@@ -322,12 +330,46 @@ async fn create_account(name: &str, description: Option<&str>, global: &GlobalAr
         description: description.map(|s| s.to_string()),
     };
 
-    let sa = client
-        .create_service_account()
-        .body(body)
+    // Raw request instead of the generated SDK method: the backend responds
+    // `200 OK` here, but the generated client (`create_service_account`) only
+    // accepts `201`, so every successful create was reported as an error even
+    // though the account was created (#98). Accept any 2xx success status.
+    let result = reqwest::Client::new()
+        .post(format!("{base_url}/api/v1/service-accounts"))
+        .header(reqwest::header::AUTHORIZATION, &auth_header)
+        .json(&body)
         .send()
-        .await
-        .map_err(|e| sdk_err("create service account", e))?;
+        .await;
+
+    let resp = match result {
+        Ok(r) => r,
+        Err(e) => {
+            spinner.finish_and_clear();
+            return Err(
+                AkError::NetworkError(format!("Create service account failed: {e}")).into(),
+            );
+        }
+    };
+
+    if !resp.status().is_success() {
+        spinner.finish_and_clear();
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(AkError::ServerError(format!(
+            "Create service account failed ({status}): {text}"
+        ))
+        .into());
+    }
+
+    let sa: CreateAccountResponse = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => {
+            spinner.finish_and_clear();
+            return Err(
+                AkError::ServerError(format!("Invalid service account response: {e}")).into(),
+            );
+        }
+    };
 
     spinner.finish_and_clear();
 
@@ -989,6 +1031,46 @@ mod tests {
 
         let global = crate::test_utils::test_global(OutputFormat::Quiet);
         assert!(create_account("ci", Some("robot"), &global).await.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    /// The backend returns `200 OK` on create; a successful create must not
+    /// be treated as an error even though the spec declares `201` (#98).
+    #[tokio::test]
+    async fn handler_create_accepts_200() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/service-accounts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sa_json(SA_ID, "svc-ci")))
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        assert!(create_account("ci", Some("robot"), &global).await.is_ok());
+        crate::test_utils::teardown_env();
+    }
+
+    /// Genuine HTTP failures must still error with the status attached.
+    #[tokio::test]
+    async fn handler_create_403_is_error() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/service-accounts"))
+            .respond_with(
+                ResponseTemplate::new(403).set_body_json(json!({"error": "admin required"})),
+            )
+            .mount(&server)
+            .await;
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = create_account("ci", None, &global).await;
+        assert!(result.is_err());
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(msg.contains("403"), "error should carry the status: {msg}");
         crate::test_utils::teardown_env();
     }
 


### PR DESCRIPTION
## Summary

`ak artifact push` for small files (single-PUT path) failed with `Upload failed: Unexpected Response ... status: 201` and exit 1 even though the backend had successfully created the artifact. The generated SDK method `upload_artifact` hard-matches only HTTP `200`, while the backend returns `201 Created` on `PUT /api/v1/repositories/{key}/artifacts/{path}`. The chunked upload path (large files) already tolerates any 2xx via raw requests, so only small files were broken.

`ak service-account create` had the opposite mismatch: the SDK accepts only `201`, the backend returns `200 OK` — same failure mode.

## Changes

- **`src/commands/artifact.rs`**: the small-file single PUT now goes through a raw reqwest request (`single_put_upload`), mirroring how `chunked_upload.rs` already works — reuses `resolve_base_url_and_auth`, accepts any 2xx success status, and reports genuine HTTP failures with status and response body (previously the raw `Response` debug dump). Editing the generated SDK is not durable since it is overwritten by `cargo run -p xtask -- generate`.
- **`src/commands/service_account.rs`**: `create_account` routed through a raw request the same way, tolerating 200-or-201.
- Wiremock handler tests: 201 accepted (regression test for this bug), 200 still accepted, nested target paths, and 4xx still errors — for both commands.

## Verification (live backend)

- Small-file push: previously exit 1 with `Unexpected Response ... status: 201`; now exit 0 and the artifact is retrievable.
- Large-file push (chunked path): still works.
- Push to a nonexistent repo: exits 1 with `Upload failed (404 Not Found): {"code":"NOT_FOUND","message":"Repository not found"}`.
- `service-account create`: previously exit 1; now exit 0.

## Gates

- `cargo build` / `cargo build --release` clean
- `cargo fmt --check` clean
- `cargo clippy --workspace -- -D warnings -A dead_code` clean
- `cargo test --workspace`: 1986 passed, 0 failed

## Follow-up (tracked in #98)

`artifact copy` (`src/commands/artifact.rs`) and `migrate` (`src/commands/migrate.rs`) still call the strict `upload_artifact` SDK method and will hit the same 201 mismatch for non-chunked uploads. The durable fix for the whole class is aligning the backend/OpenAPI declared success statuses and regenerating the SDK.

Closes #91
Refs #98
