### PR TITLE
feat(cli): transport-security guardrail for plaintext HTTP instance URLs

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -12,6 +12,7 @@ use crate::config::credentials::{
 use crate::config::{AppConfig, InstanceConfig};
 use crate::error::AkError;
 use crate::output::{self, OutputFormat};
+use crate::transport;
 
 #[derive(Subcommand)]
 pub enum AuthCommand {
@@ -175,6 +176,9 @@ async fn login(url: Option<&str>, use_token: bool, global: &GlobalArgs) -> Resul
     // Interactive: let user choose how to authenticate
     eprintln!("Logging in to '{}' ({})\n", instance_name, instance.url);
 
+    // Surface the cleartext risk before the user types anything.
+    transport::warn_if_insecure(&instance_name, &instance);
+
     let methods = &[
         "Login with username and password",
         "Paste an authentication token",
@@ -224,6 +228,17 @@ async fn login_with_token(instance_name: &str, instance: &InstanceConfig) -> Res
 }
 
 async fn login_with_password(instance_name: &str, instance: &InstanceConfig) -> Result<()> {
+    // A password sent over plaintext HTTP to a non-loopback host is readable
+    // by any on-path observer. Refuse unless the user explicitly opted in
+    // (`ak instance add --insecure-http` or AK_ALLOW_INSECURE_HTTP=1).
+    // Loopback (localhost/127.0.0.1/::1) is exempt: plain HTTP is the normal
+    // local development setup.
+    if transport::classify_url(&instance.url) == transport::TransportSecurity::HttpRemote
+        && !transport::insecure_http_allowed(instance)
+    {
+        return Err(AkError::InsecureTransport(instance.url.clone()).into());
+    }
+
     let username: String = dialoguer::Input::new()
         .with_prompt("Username")
         .interact_text()

--- a/src/commands/client.rs
+++ b/src/commands/client.rs
@@ -7,6 +7,7 @@ use crate::cli::GlobalArgs;
 use crate::config::credentials::{StoredCredential, get_credential};
 use crate::config::{AppConfig, InstanceConfig};
 use crate::error::AkError;
+use crate::transport;
 
 /// Build an authenticated SDK client for the resolved instance.
 ///
@@ -24,6 +25,10 @@ pub fn build_client(
             &owned_cred
         }
     };
+
+    // Sending a bearer token over plaintext HTTP to a non-loopback host
+    // exposes it to on-path observers; warn unless the user opted in.
+    transport::warn_if_insecure(instance_name, instance);
 
     let auth_value = format!("Bearer {}", cred.access_token);
     let mut headers = HeaderMap::new();
@@ -74,6 +79,7 @@ pub fn client_for(global: &GlobalArgs) -> Result<artifact_keeper_sdk::Client> {
 pub fn resolve_base_url_and_auth(global: &GlobalArgs) -> Result<(String, String)> {
     let config = AppConfig::load()?;
     let (name, instance) = config.resolve_instance(global.instance.as_deref())?;
+    transport::warn_if_insecure(name, instance);
     let cred = get_credential(name)?;
     let auth_header = format!("Bearer {}", cred.access_token);
     Ok((instance.url.clone(), auth_header))
@@ -113,6 +119,7 @@ mod tests {
         let instance = InstanceConfig {
             url: "https://example.com".to_string(),
             api_version: "v1".to_string(),
+            allow_insecure_http: false,
         };
         let cred = StoredCredential {
             access_token: "test-token-abc123".to_string(),
@@ -128,6 +135,7 @@ mod tests {
         let instance = InstanceConfig {
             url: "https://example.com".to_string(),
             api_version: "v1".to_string(),
+            allow_insecure_http: false,
         };
         let cred = StoredCredential {
             access_token: String::new(),
@@ -151,6 +159,7 @@ mod tests {
             let instance = InstanceConfig {
                 url: url.to_string(),
                 api_version: "v1".to_string(),
+                allow_insecure_http: false,
             };
             let cred = StoredCredential {
                 access_token: "token".to_string(),

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -327,6 +327,7 @@ mod tests {
             InstanceConfig {
                 url: "https://prod.example.com".into(),
                 api_version: "v1".into(),
+                allow_insecure_http: false,
             },
         );
         cfg.save().unwrap();

--- a/src/commands/instance.rs
+++ b/src/commands/instance.rs
@@ -6,6 +6,7 @@ use crate::cli::GlobalArgs;
 use crate::config::{AppConfig, InstanceConfig};
 use crate::error::AkError;
 use crate::output::{self, OutputFormat};
+use crate::transport;
 
 #[derive(Subcommand)]
 pub enum InstanceCommand {
@@ -20,6 +21,11 @@ pub enum InstanceCommand {
         /// API version
         #[arg(long, default_value = "v1")]
         api_version: String,
+
+        /// Acknowledge that this instance uses unencrypted HTTP to a
+        /// non-loopback host (credentials will be sent in cleartext)
+        #[arg(long)]
+        insecure_http: bool,
     },
 
     /// Remove a configured instance
@@ -51,7 +57,8 @@ impl InstanceCommand {
                 name,
                 url,
                 api_version,
-            } => add_instance(&name, &url, &api_version),
+                insecure_http,
+            } => add_instance(&name, &url, &api_version, insecure_http),
             Self::Remove { name } => remove_instance(&name),
             Self::List => list_instances(&global.format),
             Self::Use { name } => use_instance(&name),
@@ -60,7 +67,7 @@ impl InstanceCommand {
     }
 }
 
-fn add_instance(name: &str, url: &str, api_version: &str) -> Result<()> {
+fn add_instance(name: &str, url: &str, api_version: &str, insecure_http: bool) -> Result<()> {
     let mut config = AppConfig::load()?;
 
     if config.instances.contains_key(name) {
@@ -73,13 +80,14 @@ fn add_instance(name: &str, url: &str, api_version: &str) -> Result<()> {
     let url = url.trim_end_matches('/').to_string();
     let is_first = config.instances.is_empty();
 
-    config.instances.insert(
-        name.to_string(),
-        InstanceConfig {
-            url: url.clone(),
-            api_version: api_version.to_string(),
-        },
-    );
+    let instance = InstanceConfig {
+        url: url.clone(),
+        api_version: api_version.to_string(),
+        allow_insecure_http: insecure_http,
+    };
+    transport::warn_if_insecure(name, &instance);
+
+    config.instances.insert(name.to_string(), instance);
 
     if is_first {
         config.default_instance = Some(name.to_string());
@@ -222,7 +230,7 @@ mod tests {
     #[test]
     fn add_instance_first_becomes_default() {
         with_temp_config(|| {
-            add_instance("prod", "https://prod.example.com", "v1").unwrap();
+            add_instance("prod", "https://prod.example.com", "v1", false).unwrap();
 
             let config = AppConfig::load().unwrap();
             assert!(config.instances.contains_key("prod"));
@@ -234,8 +242,8 @@ mod tests {
     #[test]
     fn add_instance_second_not_default() {
         with_temp_config(|| {
-            add_instance("prod", "https://prod.example.com", "v1").unwrap();
-            add_instance("staging", "https://staging.example.com", "v1").unwrap();
+            add_instance("prod", "https://prod.example.com", "v1", false).unwrap();
+            add_instance("staging", "https://staging.example.com", "v1", false).unwrap();
 
             let config = AppConfig::load().unwrap();
             assert_eq!(config.instances.len(), 2);
@@ -246,8 +254,8 @@ mod tests {
     #[test]
     fn add_instance_duplicate_fails() {
         with_temp_config(|| {
-            add_instance("prod", "https://prod.example.com", "v1").unwrap();
-            let result = add_instance("prod", "https://other.com", "v1");
+            add_instance("prod", "https://prod.example.com", "v1", false).unwrap();
+            let result = add_instance("prod", "https://other.com", "v1", false);
             assert!(result.is_err());
         });
     }
@@ -255,7 +263,7 @@ mod tests {
     #[test]
     fn add_instance_strips_trailing_slash() {
         with_temp_config(|| {
-            add_instance("test", "https://example.com/", "v1").unwrap();
+            add_instance("test", "https://example.com/", "v1", false).unwrap();
 
             let config = AppConfig::load().unwrap();
             assert_eq!(config.instances["test"].url, "https://example.com");
@@ -265,7 +273,7 @@ mod tests {
     #[test]
     fn add_instance_custom_api_version() {
         with_temp_config(|| {
-            add_instance("test", "https://example.com", "v2").unwrap();
+            add_instance("test", "https://example.com", "v2", false).unwrap();
 
             let config = AppConfig::load().unwrap();
             assert_eq!(config.instances["test"].api_version, "v2");
@@ -277,8 +285,8 @@ mod tests {
     #[test]
     fn remove_instance_exists() {
         with_temp_config(|| {
-            add_instance("prod", "https://prod.example.com", "v1").unwrap();
-            add_instance("staging", "https://staging.example.com", "v1").unwrap();
+            add_instance("prod", "https://prod.example.com", "v1", false).unwrap();
+            add_instance("staging", "https://staging.example.com", "v1", false).unwrap();
 
             remove_instance("staging").unwrap();
 
@@ -299,8 +307,8 @@ mod tests {
     #[test]
     fn remove_default_instance_switches_default() {
         with_temp_config(|| {
-            add_instance("alpha", "https://alpha.com", "v1").unwrap();
-            add_instance("beta", "https://beta.com", "v1").unwrap();
+            add_instance("alpha", "https://alpha.com", "v1", false).unwrap();
+            add_instance("beta", "https://beta.com", "v1", false).unwrap();
 
             // alpha is default (first added)
             remove_instance("alpha").unwrap();
@@ -315,7 +323,7 @@ mod tests {
     #[test]
     fn remove_last_instance_clears_default() {
         with_temp_config(|| {
-            add_instance("only", "https://only.com", "v1").unwrap();
+            add_instance("only", "https://only.com", "v1", false).unwrap();
             remove_instance("only").unwrap();
 
             let config = AppConfig::load().unwrap();
@@ -329,8 +337,8 @@ mod tests {
     #[test]
     fn use_instance_sets_default() {
         with_temp_config(|| {
-            add_instance("prod", "https://prod.com", "v1").unwrap();
-            add_instance("staging", "https://staging.com", "v1").unwrap();
+            add_instance("prod", "https://prod.com", "v1", false).unwrap();
+            add_instance("staging", "https://staging.com", "v1", false).unwrap();
 
             use_instance("staging").unwrap();
 
@@ -360,8 +368,8 @@ mod tests {
     #[test]
     fn list_instances_with_entries() {
         with_temp_config(|| {
-            add_instance("prod", "https://prod.com", "v1").unwrap();
-            add_instance("staging", "https://staging.com", "v1").unwrap();
+            add_instance("prod", "https://prod.com", "v1", false).unwrap();
+            add_instance("staging", "https://staging.com", "v1", false).unwrap();
 
             list_instances(&OutputFormat::Quiet).unwrap();
             list_instances(&OutputFormat::Json).unwrap();
@@ -375,7 +383,7 @@ mod tests {
     #[test]
     fn info_instance_default() {
         with_temp_config(|| {
-            add_instance("prod", "https://prod.com", "v1").unwrap();
+            add_instance("prod", "https://prod.com", "v1", false).unwrap();
 
             let global = GlobalArgs {
                 format: OutputFormat::Quiet,
@@ -389,8 +397,8 @@ mod tests {
     #[test]
     fn info_instance_by_name() {
         with_temp_config(|| {
-            add_instance("prod", "https://prod.com", "v1").unwrap();
-            add_instance("staging", "https://staging.com", "v1").unwrap();
+            add_instance("prod", "https://prod.com", "v1", false).unwrap();
+            add_instance("staging", "https://staging.com", "v1", false).unwrap();
 
             let global = GlobalArgs {
                 format: OutputFormat::Json,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -32,6 +32,10 @@ pub struct InstanceConfig {
     pub url: String,
     #[serde(default = "default_api_version")]
     pub api_version: String,
+    /// User has explicitly acknowledged that this instance uses plaintext
+    /// HTTP to a non-loopback host (`ak instance add --insecure-http`).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub allow_insecure_http: bool,
 }
 
 fn default_format() -> String {
@@ -158,6 +162,7 @@ mod tests {
             InstanceConfig {
                 url: "https://prod.example.com".into(),
                 api_version: "v1".into(),
+                allow_insecure_http: false,
             },
         );
 
@@ -198,6 +203,7 @@ url = "https://test.com"
             InstanceConfig {
                 url: "https://prod.example.com".into(),
                 api_version: "v1".into(),
+                allow_insecure_http: false,
             },
         );
 
@@ -215,6 +221,7 @@ url = "https://test.com"
             InstanceConfig {
                 url: "https://staging.example.com".into(),
                 api_version: "v1".into(),
+                allow_insecure_http: false,
             },
         );
 
@@ -231,6 +238,7 @@ url = "https://test.com"
             InstanceConfig {
                 url: "https://staging.example.com".into(),
                 api_version: "v1".into(),
+                allow_insecure_http: false,
             },
         );
         config.instances.insert(
@@ -238,6 +246,7 @@ url = "https://test.com"
             InstanceConfig {
                 url: "https://prod.example.com".into(),
                 api_version: "v1".into(),
+                allow_insecure_http: false,
             },
         );
 
@@ -313,6 +322,7 @@ url = "https://test.com"
                 InstanceConfig {
                     url: "https://test.example.com".into(),
                     api_version: "v2".into(),
+                    allow_insecure_http: false,
                 },
             );
             config.save().unwrap();
@@ -364,6 +374,7 @@ url = "https://test.com"
                     InstanceConfig {
                         url: format!("https://{name}.example.com"),
                         api_version: "v1".into(),
+                        allow_insecure_http: false,
                     },
                 );
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,17 @@ pub enum AkError {
     #[diagnostic(code(ak::config_error))]
     ConfigError(String),
 
+    #[error("Refusing to send a password over unencrypted HTTP to '{0}'")]
+    #[diagnostic(
+        code(ak::insecure_transport),
+        help(
+            "Anyone on the network path can read credentials sent over plain http://. \
+             Use an https:// URL, or explicitly accept the risk by re-adding the instance \
+             with `ak instance add --insecure-http` or setting AK_ALLOW_INSECURE_HTTP=1."
+        )
+    )]
+    InsecureTransport(String),
+
     #[error(transparent)]
     #[diagnostic(code(ak::io_error))]
     Io(#[from] std::io::Error),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod commands;
 mod config;
 mod error;
 mod output;
+mod transport;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,253 @@
+//! Transport-security classification for instance URLs.
+//!
+//! The CLI sends bearer tokens (and, on interactive login, passwords) to the
+//! configured instance URL. Over plain `http://` those credentials travel in
+//! cleartext, so non-loopback HTTP instances get a loud warning — and
+//! interactive password login refuses outright — unless the user explicitly
+//! opts in. Loopback hosts (localhost / 127.0.0.0/8 / ::1) are exempt because
+//! plain HTTP is the normal local development setup.
+
+use crate::config::InstanceConfig;
+
+/// Environment variable that globally opts in to sending credentials over
+/// plaintext HTTP to non-loopback hosts.
+pub const ALLOW_INSECURE_HTTP_ENV: &str = "AK_ALLOW_INSECURE_HTTP";
+
+/// How safe it is to send credentials to a given instance URL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportSecurity {
+    /// `https://` — encrypted in transit.
+    Https,
+    /// `http://` to a loopback host — normal for local development.
+    HttpLoopback,
+    /// `http://` to a non-loopback host — credentials cross the network in
+    /// cleartext.
+    HttpRemote,
+    /// Anything else (unparseable URL, non-http scheme). Left to the HTTP
+    /// client to reject; no transport warning is emitted.
+    Other,
+}
+
+/// Classify an instance URL by how it transports credentials.
+pub fn classify_url(raw: &str) -> TransportSecurity {
+    let parsed = match url::Url::parse(raw) {
+        Ok(u) => u,
+        Err(_) => return TransportSecurity::Other,
+    };
+
+    match parsed.scheme() {
+        "https" => TransportSecurity::Https,
+        "http" => match parsed.host() {
+            Some(host) if is_loopback_host(&host) => TransportSecurity::HttpLoopback,
+            Some(_) => TransportSecurity::HttpRemote,
+            None => TransportSecurity::Other,
+        },
+        _ => TransportSecurity::Other,
+    }
+}
+
+/// Whether a parsed URL host resolves to the local machine's loopback
+/// interface: `localhost` (and `*.localhost`, per RFC 6761), `127.0.0.0/8`,
+/// or `::1` (including the IPv4-mapped form).
+fn is_loopback_host(host: &url::Host<&str>) -> bool {
+    match host {
+        url::Host::Domain(domain) => {
+            let d = domain.to_ascii_lowercase();
+            d == "localhost" || d.ends_with(".localhost")
+        }
+        url::Host::Ipv4(ip) => ip.is_loopback(),
+        url::Host::Ipv6(ip) => {
+            ip.is_loopback() || ip.to_ipv4_mapped().is_some_and(|v4| v4.is_loopback())
+        }
+    }
+}
+
+/// Whether the `AK_ALLOW_INSECURE_HTTP` environment variable opts in to
+/// plaintext HTTP for this invocation.
+pub fn insecure_http_allowed_by_env() -> bool {
+    matches!(
+        std::env::var(ALLOW_INSECURE_HTTP_ENV).as_deref(),
+        Ok("1") | Ok("true") | Ok("yes")
+    )
+}
+
+/// Whether the user has opted in to plaintext HTTP for this instance, either
+/// persistently (`ak instance add --insecure-http`) or for this invocation
+/// (`AK_ALLOW_INSECURE_HTTP=1`).
+pub fn insecure_http_allowed(instance: &InstanceConfig) -> bool {
+    instance.allow_insecure_http || insecure_http_allowed_by_env()
+}
+
+/// Emit the standard cleartext-credential warning to stderr if (and only if)
+/// the instance uses plaintext HTTP to a non-loopback host without an opt-in.
+///
+/// Returns `true` if the warning was emitted.
+pub fn warn_if_insecure(instance_name: &str, instance: &InstanceConfig) -> bool {
+    if classify_url(&instance.url) == TransportSecurity::HttpRemote
+        && !insecure_http_allowed(instance)
+    {
+        eprintln!(
+            "Warning: instance '{instance_name}' uses unencrypted HTTP ({}).\n\
+             Credentials (bearer tokens) are sent in cleartext and can be read by anyone \
+             on the network path.\n\
+             Use an https:// URL, or acknowledge the risk with \
+             `ak instance add --insecure-http` or {ALLOW_INSECURE_HTTP_ENV}=1.",
+            instance.url
+        );
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::ENV_LOCK;
+
+    fn instance(url: &str, allow: bool) -> InstanceConfig {
+        InstanceConfig {
+            url: url.to_string(),
+            api_version: "v1".to_string(),
+            allow_insecure_http: allow,
+        }
+    }
+
+    // ---- classify_url ----
+
+    #[test]
+    fn https_is_secure() {
+        assert_eq!(
+            classify_url("https://registry.example.com"),
+            TransportSecurity::Https
+        );
+        assert_eq!(
+            classify_url("https://10.1.2.3:8443/api"),
+            TransportSecurity::Https
+        );
+    }
+
+    #[test]
+    fn http_localhost_is_loopback() {
+        assert_eq!(
+            classify_url("http://localhost:8080"),
+            TransportSecurity::HttpLoopback
+        );
+        assert_eq!(
+            classify_url("http://LOCALHOST:8080"),
+            TransportSecurity::HttpLoopback
+        );
+        assert_eq!(
+            classify_url("http://registry.localhost:8080"),
+            TransportSecurity::HttpLoopback
+        );
+    }
+
+    #[test]
+    fn http_loopback_ips_are_loopback() {
+        assert_eq!(
+            classify_url("http://127.0.0.1:8080"),
+            TransportSecurity::HttpLoopback
+        );
+        assert_eq!(
+            classify_url("http://127.1.2.3"),
+            TransportSecurity::HttpLoopback
+        );
+        assert_eq!(
+            classify_url("http://[::1]:8080"),
+            TransportSecurity::HttpLoopback
+        );
+        assert_eq!(
+            classify_url("http://[::ffff:127.0.0.1]:8080"),
+            TransportSecurity::HttpLoopback
+        );
+    }
+
+    #[test]
+    fn http_remote_hosts_are_remote() {
+        assert_eq!(
+            classify_url("http://registry.example.com"),
+            TransportSecurity::HttpRemote
+        );
+        assert_eq!(
+            classify_url("http://10.0.0.5:8080"),
+            TransportSecurity::HttpRemote
+        );
+        assert_eq!(
+            classify_url("http://[2001:db8::1]:8080"),
+            TransportSecurity::HttpRemote
+        );
+        // Looks local but is NOT loopback — traffic still leaves the host.
+        assert_eq!(
+            classify_url("http://localhost.example.com"),
+            TransportSecurity::HttpRemote
+        );
+        assert_eq!(
+            classify_url("http://192.168.1.10"),
+            TransportSecurity::HttpRemote
+        );
+    }
+
+    #[test]
+    fn non_http_and_garbage_are_other() {
+        assert_eq!(classify_url("ftp://example.com"), TransportSecurity::Other);
+        assert_eq!(classify_url("not a url"), TransportSecurity::Other);
+        assert_eq!(classify_url(""), TransportSecurity::Other);
+    }
+
+    // ---- opt-in resolution ----
+
+    #[test]
+    fn env_opt_in_values() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for (val, expected) in [
+            ("1", true),
+            ("true", true),
+            ("yes", true),
+            ("0", false),
+            ("false", false),
+            ("", false),
+        ] {
+            unsafe { std::env::set_var(ALLOW_INSECURE_HTTP_ENV, val) };
+            assert_eq!(insecure_http_allowed_by_env(), expected, "value: {val:?}");
+        }
+        unsafe { std::env::remove_var(ALLOW_INSECURE_HTTP_ENV) };
+        assert!(!insecure_http_allowed_by_env());
+    }
+
+    #[test]
+    fn instance_flag_opts_in() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::remove_var(ALLOW_INSECURE_HTTP_ENV) };
+        assert!(insecure_http_allowed(&instance("http://example.com", true)));
+        assert!(!insecure_http_allowed(&instance(
+            "http://example.com",
+            false
+        )));
+    }
+
+    // ---- warn_if_insecure ----
+
+    #[test]
+    fn warns_only_for_unacknowledged_remote_http() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::remove_var(ALLOW_INSECURE_HTTP_ENV) };
+
+        assert!(warn_if_insecure(
+            "t",
+            &instance("http://registry.example.com", false)
+        ));
+        assert!(!warn_if_insecure(
+            "t",
+            &instance("http://registry.example.com", true)
+        ));
+        assert!(!warn_if_insecure(
+            "t",
+            &instance("http://localhost:8080", false)
+        ));
+        assert!(!warn_if_insecure(
+            "t",
+            &instance("https://registry.example.com", false)
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a transport-security guardrail so users can no longer send credentials over plaintext HTTP to a remote host without knowing about it, while keeping local-development workflows (plain HTTP to loopback) completely frictionless.

Closes #133

### Behavior

| Instance URL | `instance add` | Authenticated API calls | Interactive password login |
|---|---|---|---|
| `https://…` | unchanged | unchanged | unchanged |
| `http://` loopback (`localhost`, `*.localhost`, `127.0.0.0/8`, `::1`) | unchanged | unchanged | unchanged |
| `http://` non-loopback, no opt-in | stderr warning (still added) | stderr warning (call proceeds) | refused with `ak::insecure_transport` diagnostic |
| `http://` non-loopback, opted in | silent | silent | proceeds |

### Opt-ins

- `ak instance add <name> <url> --insecure-http` — persists `allow_insecure_http = true` for that instance in `config.toml` (field is omitted when false, so existing configs round-trip unchanged).
- `AK_ALLOW_INSECURE_HTTP=1` (also `true`/`yes`) — per-invocation override.

### Implementation

- New `src/transport.rs` with `classify_url()` (Https / HttpLoopback / HttpRemote / Other), opt-in resolution, and the shared warning emitter; loopback covers `localhost`, `*.localhost` (RFC 6761), `127.0.0.0/8`, `::1`, and IPv4-mapped `::ffff:127.x`.
- Guard wired into `instance add`, `build_client`, `resolve_base_url_and_auth` (chunked upload raw HTTP), and the interactive login flow; `login_with_password` refuses on unacknowledged remote HTTP.
- New `AkError::InsecureTransport` miette diagnostic with help text pointing at both opt-ins.
- Deliberately does NOT set `reqwest`'s global `https_only(true)` — that would break plain-HTTP loopback development instances.

## Test Checklist

- [x] `cargo build` and `cargo build --release` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings -A dead_code` clean
- [x] `cargo test --workspace` — 2017 passed, 0 failed (includes new unit tests for URL classification, loopback carve-out, env/flag opt-in resolution, and warning gating)
- [x] Manual: interactive `ak auth login` (username/password) against a local `http://localhost:8080` instance succeeds with no warning and no refusal
- [x] Manual: `ak instance add rem http://registry.example.com` warns on stderr; interactive password login against it fails with `ak::insecure_transport`; token-based API call warns but proceeds
- [x] Manual: `--insecure-http` at add time persists `allow_insecure_http = true` and silences the guard; `AK_ALLOW_INSECURE_HTTP=1` does the same per-invocation
- [x] Manual: `https://` instances produce no warnings

## API Changes

None (CLI-only). New CLI flag `ak instance add --insecure-http`, new env var `AK_ALLOW_INSECURE_HTTP`, new optional `allow_insecure_http` key in `config.toml`.