### PR TITLE
fix(output): sanitize server-derived strings before terminal display

### DIFF
--- a/src/commands/artifact.rs
+++ b/src/commands/artifact.rs
@@ -425,7 +425,7 @@ async fn list(
 
     if matches!(global.format, OutputFormat::Quiet) {
         for a in &resp.items {
-            println!("{}", a.path);
+            println!("{}", output::sanitize_terminal(&a.path));
         }
         return Ok(());
     }
@@ -454,15 +454,16 @@ async fn list(
             .set_header(vec!["PATH", "VERSION", "SIZE", "DOWNLOADS", "CREATED"]);
 
         for a in &resp.items {
-            let version = a.version.as_deref().unwrap_or("-");
+            let path = output::sanitize_terminal(&a.path);
+            let version = output::sanitize_terminal(a.version.as_deref().unwrap_or("-"));
             let size = format_bytes(a.size_bytes);
             let created = a.created_at.format("%Y-%m-%d").to_string();
             table.add_row(vec![
-                a.path.as_str(),
+                path,
                 version,
-                &size,
-                &a.download_count.to_string(),
-                &created,
+                size,
+                a.download_count.to_string(),
+                created,
             ]);
         }
 
@@ -741,7 +742,7 @@ async fn search(
 
     if matches!(global.format, OutputFormat::Quiet) {
         for item in &resp.items {
-            println!("{}", item.name);
+            println!("{}", output::sanitize_terminal(&item.name));
         }
         return Ok(());
     }
@@ -770,19 +771,15 @@ async fn search(
             .set_header(vec!["NAME", "REPOSITORY", "FORMAT", "VERSION", "SIZE"]);
 
         for item in &resp.items {
-            let version = item.version.as_deref().unwrap_or("-");
-            let format_str = item.format.as_deref().unwrap_or("-");
+            let name = output::sanitize_terminal(&item.name);
+            let repository = output::sanitize_terminal(&item.repository_key);
+            let version = output::sanitize_terminal(item.version.as_deref().unwrap_or("-"));
+            let format_str = output::sanitize_terminal(item.format.as_deref().unwrap_or("-"));
             let size = item
                 .size_bytes
                 .map(format_bytes)
                 .unwrap_or_else(|| "-".into());
-            table.add_row(vec![
-                item.name.as_str(),
-                item.repository_key.as_str(),
-                format_str,
-                version,
-                &size,
-            ]);
+            table.add_row(vec![name, repository, format_str, version, size]);
         }
 
         table.to_string()

--- a/src/commands/label.rs
+++ b/src/commands/label.rs
@@ -142,7 +142,11 @@ async fn list_labels(repo_key: &str, global: &GlobalArgs) -> Result<()> {
 
     if matches!(global.format, OutputFormat::Quiet) {
         for l in &resp.items {
-            println!("{}={}", l.key, l.value);
+            println!(
+                "{}={}",
+                output::sanitize_terminal(&l.key),
+                output::sanitize_terminal(&l.value)
+            );
         }
         return Ok(());
     }
@@ -165,7 +169,11 @@ async fn list_labels(repo_key: &str, global: &GlobalArgs) -> Result<()> {
 
         for l in &resp.items {
             let created = l.created_at.format("%Y-%m-%d").to_string();
-            table.add_row(vec![&l.key, &l.value, &created]);
+            table.add_row(vec![
+                output::sanitize_terminal(&l.key),
+                output::sanitize_terminal(&l.value),
+                created,
+            ]);
         }
 
         table.to_string()
@@ -221,9 +229,9 @@ fn format_label_table(items: &[serde_json::Value]) -> String {
 
     for l in items {
         table.add_row(vec![
-            l["key"].as_str().unwrap_or("-"),
-            l["value"].as_str().unwrap_or("-"),
-            l["created_at"].as_str().unwrap_or("-"),
+            output::sanitize_terminal(l["key"].as_str().unwrap_or("-")),
+            output::sanitize_terminal(l["value"].as_str().unwrap_or("-")),
+            output::sanitize_terminal(l["created_at"].as_str().unwrap_or("-")),
         ]);
     }
 
@@ -340,7 +348,11 @@ async fn list_artifact_labels(id: &str, global: &GlobalArgs) -> Result<()> {
 
     if matches!(global.format, OutputFormat::Quiet) {
         for l in &resp.items {
-            println!("{}={}", l.key, l.value);
+            println!(
+                "{}={}",
+                output::sanitize_terminal(&l.key),
+                output::sanitize_terminal(&l.value)
+            );
         }
         return Ok(());
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -22,13 +22,59 @@ impl OutputFormat {
     }
 }
 
+/// Returns `true` for control characters that must not be written verbatim to a
+/// terminal. Covers the C0 range (0x00–0x1F, including ESC 0x1B, BEL 0x07 and CR
+/// 0x0D), DEL (0x7F) and the C1 range (0x80–0x9F). Tab (0x09) and line feed
+/// (0x0A) are intentionally allowed so tables and multi-line values still render.
+fn is_unsafe_control(c: char) -> bool {
+    match c {
+        '\t' | '\n' => false,
+        '\u{00}'..='\u{1f}' | '\u{7f}' => true,
+        '\u{80}'..='\u{9f}' => true,
+        _ => false,
+    }
+}
+
+/// Neutralize server-derived strings before they are displayed on a terminal.
+///
+/// A malicious publisher or hostile server can embed ANSI/OSC/cursor-control
+/// escape sequences in artifact names, paths, labels, descriptions or search
+/// results. When those are printed verbatim they execute in the victim's
+/// terminal: spoofing output, rewriting the window title, hiding or overwriting
+/// lines, or triggering terminal-emulator exploits. This helper rewrites every
+/// dangerous control character into its visible, inert escaped form (e.g. ESC
+/// becomes the literal text `\u{1b}`) so the data stays readable but can no
+/// longer drive the terminal. Tab and newline are preserved.
+///
+/// This must only be applied to human/quiet display paths. JSON and YAML output
+/// is already safe (serde escapes control characters) and is the machine-readable
+/// path, so it must not be run through this function.
+pub fn sanitize_terminal(s: &str) -> String {
+    if !s.chars().any(is_unsafe_control) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        if is_unsafe_control(c) {
+            out.extend(c.escape_default());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Render any serializable data in the requested format.
 /// For table output, the caller should provide a pre-formatted table string.
 pub fn render<T: Serialize>(data: &T, format: &OutputFormat, table: Option<String>) -> String {
     match format {
-        OutputFormat::Table => {
-            table.unwrap_or_else(|| serde_json::to_string_pretty(data).unwrap_or_default())
-        }
+        // The table/human path is a terminal display surface, so any
+        // server-derived content it carries is sanitized centrally here. Box
+        // drawing, tabs and newlines are preserved; escape/control bytes are
+        // neutralized. JSON/YAML below are left untouched (serde-escaped).
+        OutputFormat::Table => sanitize_terminal(
+            &table.unwrap_or_else(|| serde_json::to_string_pretty(data).unwrap_or_default()),
+        ),
         OutputFormat::Json => {
             if console::Term::stdout().is_term() {
                 serde_json::to_string_pretty(data).unwrap_or_default()
@@ -224,5 +270,76 @@ mod tests {
         let fmt = OutputFormat::Quiet;
         let resolved = fmt.resolve(false);
         assert!(matches!(resolved, OutputFormat::Quiet));
+    }
+
+    // ---- sanitize_terminal ----
+
+    #[test]
+    fn sanitize_leaves_plain_text_untouched() {
+        let s = "artifact-1.2.3.tar.gz";
+        assert_eq!(sanitize_terminal(s), s);
+    }
+
+    #[test]
+    fn sanitize_preserves_tab_and_newline() {
+        let s = "col1\tcol2\nrow2";
+        assert_eq!(sanitize_terminal(s), s);
+    }
+
+    #[test]
+    fn sanitize_neutralizes_ansi_color_escape() {
+        // ESC [ 31 m ... ESC [ 0 m
+        let s = "\x1b[31;1mSYSTEM_OK\x1b[0m";
+        let out = sanitize_terminal(s);
+        assert!(!out.contains('\x1b'), "raw ESC (0x1b) must be gone");
+        assert!(out.contains("SYSTEM_OK"), "readable text must survive");
+        assert!(out.contains("\\u{1b}"), "ESC should be shown escaped");
+    }
+
+    #[test]
+    fn sanitize_neutralizes_osc_title_and_bel() {
+        // OSC 0 ; PWNED BEL — rewrites the terminal title
+        let s = "\x1b]0;PWNED\x07";
+        let out = sanitize_terminal(s);
+        assert!(!out.contains('\x1b'), "raw ESC must be gone");
+        assert!(!out.contains('\x07'), "raw BEL (0x07) must be gone");
+        assert!(out.contains("PWNED"));
+    }
+
+    #[test]
+    fn sanitize_neutralizes_carriage_return_and_c1() {
+        let s = "visible\rHIDDEN\u{85}tail";
+        let out = sanitize_terminal(s);
+        assert!(!out.contains('\r'), "CR must be neutralized");
+        assert!(!out.contains('\u{85}'), "C1 control must be neutralized");
+        assert!(out.contains("visible"));
+        assert!(out.contains("HIDDEN"));
+    }
+
+    #[test]
+    fn sanitize_is_stable_when_applied_twice() {
+        let once = sanitize_terminal("\x1b[31mx\x1b[0m");
+        let twice = sanitize_terminal(&once);
+        assert_eq!(once, twice, "sanitizing already-safe text is a no-op");
+    }
+
+    #[test]
+    fn render_table_sanitizes_embedded_escape() {
+        let data = serde_json::json!({"k": "v"});
+        let table = "PATH\n\x1b[31mrtansi\x1b]0;PWNED\x07".to_string();
+        let out = render(&data, &OutputFormat::Table, Some(table));
+        assert!(!out.contains('\x1b'), "table path must strip raw ESC");
+        assert!(!out.contains('\x07'), "table path must strip raw BEL");
+        assert!(out.contains("rtansi"));
+    }
+
+    #[test]
+    fn render_json_does_not_alter_serde_escaping() {
+        // JSON is the machine-readable safe path: serde already escapes controls.
+        let data = serde_json::json!({"name": "\x1b[31mx"});
+        let out = render(&data, &OutputFormat::Json, None);
+        assert!(!out.contains('\x1b'), "serde emits no raw ESC");
+        // serde renders the control byte as , not our \u{1b} form.
+        assert!(out.contains("\\u001b"));
     }
 }


### PR DESCRIPTION
## Summary

Server-derived strings displayed by the CLI (artifact names/paths, labels, search results) were printed to the terminal without any control-character sanitization. A malicious publisher or hostile server could embed ANSI/OSC/cursor-control escape sequences in those fields; when a victim runs a normal command such as `ak artifact list`, `ak artifact search`, or `ak label repo list`, the escapes are emitted verbatim and executed by the terminal emulator (spoofed output, terminal-title rewriting, hidden/overwritten lines, potential terminal-emulator exploits). The quiet/pipe path leaked raw control bytes too, so scripts capturing output were also at risk.

This change:

- Adds a central `sanitize_terminal(&str) -> String` helper in `src/output/mod.rs` that rewrites C0 controls (0x00-0x1F, including ESC 0x1B, BEL 0x07, CR 0x0D), DEL (0x7F) and C1 controls (0x80-0x9F) into their visible, inert escaped form (ESC becomes the literal text backslash-u-1b). Tab and newline are preserved so tables and multi-line values still render.
- Applies it centrally in the `render` table branch, which covers all human table/detail output, and additionally at the quiet-mode `println!` value paths and table row builders for labels and artifacts.
- Leaves JSON/YAML serialization untouched — serde already escapes control characters and is the machine-readable path.

## Behavior (before / after)

Reproduction adds a label whose value contains an ANSI color sequence plus an OSC terminal-title sequence ending in BEL, then lists it in table and quiet modes.

- Before: the value rendered with raw ESC and BEL bytes present in both table and quiet output (visible as `^[` and `^G` under `cat -v`), which the terminal interprets.
- After: the same value renders in its escaped, inert form (ESC shown as literal `\u{1b}`, BEL as `\u{7}`) with no raw control bytes, in both table and quiet modes.
- `--format json` output is unchanged (serde-escaped `` / ``).

## Test Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo build` / `cargo build --release`
- [x] `cargo test --workspace` (all pass; added 8 unit tests covering ANSI color, OSC title + BEL, CR/C1, tab/newline preservation, idempotence, the render table path, and that JSON serde-escaping is unaffected)
- [x] Live reproduction confirmed blocked in table and quiet modes; JSON output verified unchanged

## API Changes

None.

Closes #135
