### PR TITLE
Add prompt/stdin/env alternatives for secret-valued CLI options

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -4,7 +4,7 @@ use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 use miette::{IntoDiagnostic, Result};
 
 use super::client::{authenticated_client, build_client, client_for};
-use super::helpers::{parse_uuid, sdk_err};
+use super::helpers::{parse_uuid, resolve_secret, sdk_err};
 use crate::cli::GlobalArgs;
 use crate::config::credentials::{
     StoredCredential, delete_credential, get_credential, store_credential,
@@ -82,8 +82,13 @@ pub enum AuthCommand {
         provider_id: String,
 
         /// The OIDC JWT to exchange (falls back to the AK_CI_JWT env var)
-        #[arg(long, env = "AK_CI_JWT")]
+        #[arg(long, env = "AK_CI_JWT", hide_env_values = true)]
         jwt: Option<String>,
+
+        /// Read the OIDC JWT from stdin (avoids exposing it on the command
+        /// line)
+        #[arg(long)]
+        jwt_stdin: bool,
     },
 
     /// Show whether initial setup (password change) is required
@@ -132,7 +137,15 @@ impl AuthCommand {
                 resource_path,
                 purpose,
             } => download_ticket(&resource_path, &purpose, global).await,
-            Self::CiExchange { provider_id, jwt } => {
+            Self::CiExchange {
+                provider_id,
+                jwt,
+                jwt_stdin,
+            } => {
+                // Resolve the JWT off the command line: --jwt-stdin / piped
+                // stdin / AK_CI_JWT / no-echo prompt on a TTY.
+                let jwt =
+                    resolve_secret(jwt, jwt_stdin, "--jwt", Some("OIDC JWT"), global.no_input)?;
                 ci_exchange(&provider_id, jwt.as_deref(), global).await
             }
             Self::SetupStatus => setup_status(global).await,
@@ -435,7 +448,10 @@ async fn download_ticket(resource_path: &str, purpose: &str, global: &GlobalArgs
 async fn ci_exchange(provider_id: &str, jwt: Option<&str>, global: &GlobalArgs) -> Result<()> {
     let provider = parse_uuid(provider_id, "provider")?;
     let jwt = jwt.ok_or_else(|| {
-        AkError::ConfigError("No OIDC JWT provided. Pass --jwt <token> or set AK_CI_JWT.".into())
+        AkError::ConfigError(
+            "No OIDC JWT provided. Pipe it to --jwt-stdin, set AK_CI_JWT, or pass --jwt <token>."
+                .into(),
+        )
     })?;
 
     let config = AppConfig::load()?;
@@ -933,9 +949,30 @@ mod tests {
             "--jwt",
             "ey.jwt.here",
         ]) {
-            AuthCommand::CiExchange { provider_id, jwt } => {
+            AuthCommand::CiExchange {
+                provider_id,
+                jwt,
+                jwt_stdin,
+            } => {
                 assert_eq!(provider_id, "00000000-0000-0000-0000-000000000000");
                 assert_eq!(jwt.as_deref(), Some("ey.jwt.here"));
+                assert!(!jwt_stdin);
+            }
+            _ => panic!("expected CiExchange"),
+        }
+    }
+
+    #[test]
+    fn parse_ci_exchange_jwt_stdin() {
+        match parse_auth(&[
+            "auth",
+            "ci-exchange",
+            "--provider-id",
+            "00000000-0000-0000-0000-000000000000",
+            "--jwt-stdin",
+        ]) {
+            AuthCommand::CiExchange { jwt_stdin, .. } => {
+                assert!(jwt_stdin);
             }
             _ => panic!("expected CiExchange"),
         }

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -55,6 +55,111 @@ pub fn parse_optional_uuid(id: Option<&str>, label: &str) -> Result<Option<uuid:
     id.map(|v| parse_uuid(v, label)).transpose()
 }
 
+/// True when the given long option (e.g. `--password`) appears on the
+/// command line itself, as opposed to being filled from an env var default.
+fn flag_on_argv(flag: &str) -> bool {
+    std::env::args().skip(1).any(|arg| {
+        arg == flag
+            || arg
+                .strip_prefix(flag)
+                .is_some_and(|rest| rest.starts_with('='))
+    })
+}
+
+/// Return `None` for an empty secret so "just press Enter" and empty piped
+/// input both mean "no secret".
+fn non_empty(secret: String) -> Option<String> {
+    if secret.is_empty() {
+        None
+    } else {
+        Some(secret)
+    }
+}
+
+/// Read a secret from a reader (stdin), trimming trailing newlines.
+fn read_secret<R: std::io::Read>(reader: &mut R) -> Result<String> {
+    let mut buf = String::new();
+    reader
+        .read_to_string(&mut buf)
+        .map_err(|e| AkError::ConfigError(format!("Failed to read secret from stdin: {e}")))?;
+    Ok(buf.trim_end_matches(['\r', '\n']).to_string())
+}
+
+/// Resolve a secret-valued option without requiring it on the command line.
+///
+/// Sources, in order of precedence:
+/// 1. `from_stdin` (`--<flag>-stdin` was passed): read the secret from stdin.
+/// 2. An explicit value (`--<flag> <value>` on argv, or its env-var default).
+///    When the value was visibly passed on argv, a soft warning is printed to
+///    stderr since command-line values leak into shell history and process
+///    listings.
+/// 3. If `prompt` is `Some` and stdin is not a TTY (piped/redirected input),
+///    read the secret from stdin.
+/// 4. If `prompt` is `Some`, stdin is a TTY, and `--no-input` was not given,
+///    prompt interactively with no echo. Empty input means "no secret".
+/// 5. Otherwise resolve to `None`.
+///
+/// Pass `prompt: None` for inputs that must never fall back to prompting or
+/// implicit stdin reads (e.g. update commands where an omitted secret means
+/// "keep the existing one").
+pub fn resolve_secret(
+    value: Option<String>,
+    from_stdin: bool,
+    flag: &str,
+    prompt: Option<&str>,
+    no_input: bool,
+) -> Result<Option<String>> {
+    if value.is_some() && flag_on_argv(flag) {
+        eprintln!(
+            "warning: passing {flag} on the command line exposes the secret to shell history \
+             and process listings; prefer {flag}-stdin, the corresponding environment \
+             variable, or the interactive prompt"
+        );
+    }
+    let stdin_is_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
+    resolve_secret_from(value, from_stdin, prompt, no_input, stdin_is_tty, || {
+        std::io::stdin().lock()
+    })
+}
+
+/// Testable core of [`resolve_secret`]; see its docs for the precedence rules.
+///
+/// `reader` is only invoked on the branches that actually read stdin — it must
+/// NOT be acquired eagerly, because the interactive prompt also reads from
+/// stdin and a held `StdinLock` would deadlock it.
+fn resolve_secret_from<R: std::io::Read>(
+    value: Option<String>,
+    from_stdin: bool,
+    prompt: Option<&str>,
+    no_input: bool,
+    stdin_is_tty: bool,
+    reader: impl FnOnce() -> R,
+) -> Result<Option<String>> {
+    if from_stdin {
+        return read_secret(&mut reader()).map(non_empty);
+    }
+    if value.is_some() {
+        return Ok(value);
+    }
+    let Some(prompt) = prompt else {
+        return Ok(None);
+    };
+    if !stdin_is_tty {
+        // Piped/redirected input: take the secret from stdin so it never has
+        // to appear on the command line.
+        return read_secret(&mut reader()).map(non_empty);
+    }
+    if no_input {
+        return Ok(None);
+    }
+    let entered = dialoguer::Password::new()
+        .with_prompt(prompt)
+        .allow_empty_password(true)
+        .interact()
+        .into_diagnostic()?;
+    Ok(non_empty(entered))
+}
+
 /// Prompt the user to confirm a destructive action. Returns `true` if the
 /// action should proceed, `false` if cancelled.
 pub fn confirm_action(prompt: &str, skip_confirm: bool, no_input: bool) -> Result<bool> {
@@ -227,5 +332,102 @@ mod tests {
         assert!(s.contains("A"));
         assert!(s.contains("B"));
         assert!(s.contains("C"));
+    }
+
+    // ---- resolve_secret_from ----
+
+    fn cursor(s: &str) -> std::io::Cursor<Vec<u8>> {
+        std::io::Cursor::new(s.as_bytes().to_vec())
+    }
+
+    #[test]
+    fn secret_from_stdin_flag_reads_and_trims() {
+        let mut input = cursor("s3cr3t\n");
+        let got =
+            resolve_secret_from(None, true, Some("Secret"), false, true, || &mut input).unwrap();
+        assert_eq!(got.as_deref(), Some("s3cr3t"));
+    }
+
+    #[test]
+    fn secret_from_stdin_flag_trims_crlf() {
+        let mut input = cursor("s3cr3t\r\n");
+        let got =
+            resolve_secret_from(None, true, Some("Secret"), false, true, || &mut input).unwrap();
+        assert_eq!(got.as_deref(), Some("s3cr3t"));
+    }
+
+    #[test]
+    fn secret_from_stdin_flag_wins_over_value() {
+        let mut input = cursor("from-stdin\n");
+        let got = resolve_secret_from(
+            Some("from-flag".into()),
+            true,
+            Some("Secret"),
+            false,
+            true,
+            || &mut input,
+        )
+        .unwrap();
+        assert_eq!(got.as_deref(), Some("from-stdin"));
+    }
+
+    #[test]
+    fn secret_from_stdin_flag_empty_means_none() {
+        let mut input = cursor("\n");
+        let got =
+            resolve_secret_from(None, true, Some("Secret"), false, true, || &mut input).unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn secret_explicit_value_used_verbatim() {
+        let mut input = cursor("ignored");
+        let got = resolve_secret_from(
+            Some("from-flag".into()),
+            false,
+            Some("Secret"),
+            true,
+            false,
+            || &mut input,
+        )
+        .unwrap();
+        assert_eq!(got.as_deref(), Some("from-flag"));
+        // Nothing was consumed from stdin.
+        assert_eq!(input.position(), 0);
+    }
+
+    #[test]
+    fn secret_piped_stdin_read_when_omitted() {
+        let mut input = cursor("piped-secret\n");
+        let got =
+            resolve_secret_from(None, false, Some("Secret"), false, false, || &mut input).unwrap();
+        assert_eq!(got.as_deref(), Some("piped-secret"));
+    }
+
+    #[test]
+    fn secret_piped_stdin_empty_means_none() {
+        let mut input = cursor("");
+        let got =
+            resolve_secret_from(None, false, Some("Secret"), true, false, || &mut input).unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn secret_no_input_on_tty_means_none() {
+        let mut input = cursor("should-not-be-read");
+        let got =
+            resolve_secret_from(None, false, Some("Secret"), true, true, || &mut input).unwrap();
+        assert_eq!(got, None);
+        assert_eq!(input.position(), 0);
+    }
+
+    #[test]
+    fn secret_without_prompt_never_reads_stdin() {
+        // prompt: None = update-style flows; omitted secret stays omitted even
+        // when stdin is piped.
+        let mut input = cursor("should-not-be-read");
+        let got = resolve_secret_from(None, false, None, false, false, || &mut input).unwrap();
+        assert_eq!(got, None);
+        assert_eq!(input.position(), 0);
     }
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -21,7 +21,7 @@ use miette::Result;
 use serde_json::Value;
 
 use super::client::{client_for, resolve_base_url_and_auth};
-use super::helpers::{new_table, parse_uuid, sdk_err, short_id};
+use super::helpers::{new_table, parse_uuid, resolve_secret, sdk_err, short_id};
 use crate::cli::GlobalArgs;
 use crate::error::AkError;
 use crate::output::{self, OutputFormat, format_bytes};
@@ -70,13 +70,23 @@ pub enum SourceCommand {
         #[arg(long)]
         username: Option<String>,
 
-        /// Password for basic auth
-        #[arg(long)]
+        /// Password for basic auth (omit to be prompted, or pipe it to stdin)
+        #[arg(long, env = "AK_IMPORT_PASSWORD", hide_env_values = true)]
         password: Option<String>,
 
-        /// API token / access token
+        /// Read the basic-auth password from stdin (avoids exposing it on the
+        /// command line)
         #[arg(long)]
+        password_stdin: bool,
+
+        /// API token / access token (omit to be prompted, or pipe it to stdin)
+        #[arg(long, env = "AK_IMPORT_TOKEN", hide_env_values = true)]
         token: Option<String>,
+
+        /// Read the API token from stdin (avoids exposing it on the command
+        /// line)
+        #[arg(long)]
+        token_stdin: bool,
     },
 
     /// Show a specific source connection
@@ -260,8 +270,26 @@ impl SourceCommand {
                 source_type,
                 username,
                 password,
+                password_stdin,
                 token,
+                token_stdin,
             } => {
+                // Resolve secrets off the command line: prompt on a TTY (or
+                // read piped stdin) for the credential matching the auth type.
+                let password = resolve_secret(
+                    password,
+                    password_stdin,
+                    "--password",
+                    (auth_type == "basic_auth").then_some("Source password (leave empty for none)"),
+                    global.no_input,
+                )?;
+                let token = resolve_secret(
+                    token,
+                    token_stdin,
+                    "--token",
+                    (auth_type == "api_token").then_some("Source API token (leave empty for none)"),
+                    global.no_input,
+                )?;
                 source_add(
                     &name,
                     &url,
@@ -1320,6 +1348,64 @@ mod tests {
                 assert_eq!(url, "https://artifactory.corp");
                 assert_eq!(source_type.as_deref(), Some("artifactory"));
                 assert_eq!(username.as_deref(), Some("admin"));
+            }
+            _ => panic!("expected Source Add"),
+        }
+    }
+
+    #[test]
+    fn parses_source_add_password_stdin() {
+        let cli = TestCli::parse_from([
+            "ak",
+            "source",
+            "add",
+            "legacy",
+            "https://artifactory.corp",
+            "--username",
+            "admin",
+            "--password-stdin",
+        ]);
+        match cli.command {
+            ImportCommand::Source(SourceCommand::Add {
+                password,
+                password_stdin,
+                token,
+                token_stdin,
+                ..
+            }) => {
+                assert!(password.is_none());
+                assert!(password_stdin);
+                assert!(token.is_none());
+                assert!(!token_stdin);
+            }
+            _ => panic!("expected Source Add"),
+        }
+    }
+
+    #[test]
+    fn parses_source_add_token_stdin() {
+        let cli = TestCli::parse_from([
+            "ak",
+            "source",
+            "add",
+            "legacy",
+            "https://nexus.corp",
+            "--auth-type",
+            "api_token",
+            "--token-stdin",
+        ]);
+        match cli.command {
+            ImportCommand::Source(SourceCommand::Add {
+                auth_type,
+                token,
+                token_stdin,
+                password_stdin,
+                ..
+            }) => {
+                assert_eq!(auth_type, "api_token");
+                assert!(token.is_none());
+                assert!(token_stdin);
+                assert!(!password_stdin);
             }
             _ => panic!("expected Source Add"),
         }

--- a/src/commands/sso.rs
+++ b/src/commands/sso.rs
@@ -9,7 +9,9 @@ use miette::Result;
 use serde_json::Value;
 
 use super::client::client_for;
-use super::helpers::{confirm_action, emit_mutation, new_table, parse_uuid, sdk_err, short_id};
+use super::helpers::{
+    confirm_action, emit_mutation, new_table, parse_uuid, resolve_secret, sdk_err, short_id,
+};
 use crate::cli::GlobalArgs;
 use crate::error::AkError;
 use crate::output::{self, OutputFormat};
@@ -126,8 +128,14 @@ pub enum SsoUpdateCommand {
         #[arg(long)]
         bind_dn: Option<String>,
 
+        /// New bind password (omit to keep the existing one)
         #[arg(long)]
         bind_password: Option<String>,
+
+        /// Read the new bind password from stdin (avoids exposing it on the
+        /// command line)
+        #[arg(long)]
+        bind_password_stdin: bool,
 
         #[arg(long)]
         group_base_dn: Option<String>,
@@ -164,8 +172,14 @@ pub enum SsoUpdateCommand {
         #[arg(long)]
         client_id: Option<String>,
 
+        /// New client secret (omit to keep the existing one)
         #[arg(long)]
         client_secret: Option<String>,
+
+        /// Read the new client secret from stdin (avoids exposing it on the
+        /// command line)
+        #[arg(long)]
+        client_secret_stdin: bool,
 
         /// Auto-provision users on first login (true/false)
         #[arg(long)]
@@ -255,8 +269,14 @@ pub enum SsoCreateCommand {
         #[arg(long)]
         bind_dn: Option<String>,
 
-        #[arg(long)]
+        /// Bind password (omit to enter interactively, or pipe it to stdin)
+        #[arg(long, env = "AK_LDAP_BIND_PASSWORD", hide_env_values = true)]
         bind_password: Option<String>,
+
+        /// Read the bind password from stdin (avoids exposing it on the
+        /// command line)
+        #[arg(long)]
+        bind_password_stdin: bool,
 
         #[arg(long)]
         use_starttls: bool,
@@ -273,9 +293,14 @@ pub enum SsoCreateCommand {
         #[arg(long)]
         client_id: String,
 
-        /// Client secret (omit to enter interactively)
-        #[arg(long)]
+        /// Client secret (omit to enter interactively, or pipe it to stdin)
+        #[arg(long, env = "AK_SSO_CLIENT_SECRET", hide_env_values = true)]
         client_secret: Option<String>,
+
+        /// Read the client secret from stdin (avoids exposing it on the
+        /// command line)
+        #[arg(long)]
+        client_secret_stdin: bool,
 
         #[arg(long)]
         auto_create_users: bool,
@@ -312,8 +337,19 @@ impl SsoCommand {
                     user_base_dn,
                     bind_dn,
                     bind_password,
+                    bind_password_stdin,
                     use_starttls,
                 } => {
+                    // Resolve the bind password off the command line; only
+                    // prompt when a bind DN was given (anonymous binds need
+                    // no password).
+                    let bind_password = resolve_secret(
+                        bind_password,
+                        bind_password_stdin,
+                        "--bind-password",
+                        bind_dn.as_ref().map(|_| "LDAP bind password"),
+                        global.no_input,
+                    )?;
                     create_ldap(
                         &name,
                         &server_url,
@@ -330,8 +366,18 @@ impl SsoCommand {
                     issuer_url,
                     client_id,
                     client_secret,
+                    client_secret_stdin,
                     auto_create_users,
                 } => {
+                    // Resolve the client secret off the command line: stdin /
+                    // env var / no-echo prompt on a TTY.
+                    let client_secret = resolve_secret(
+                        client_secret,
+                        client_secret_stdin,
+                        "--client-secret",
+                        Some("OIDC client secret"),
+                        global.no_input,
+                    )?;
                     create_oidc(
                         &name,
                         &issuer_url,
@@ -386,6 +432,7 @@ impl SsoUpdateCommand {
                 groups_attribute,
                 bind_dn,
                 bind_password,
+                bind_password_stdin,
                 group_base_dn,
                 group_filter,
                 admin_group_dn,
@@ -393,6 +440,15 @@ impl SsoUpdateCommand {
                 priority,
                 is_enabled,
             } => {
+                // No prompt fallback on update: an omitted password means
+                // "keep the existing one".
+                let bind_password = resolve_secret(
+                    bind_password,
+                    bind_password_stdin,
+                    "--bind-password",
+                    None,
+                    global.no_input,
+                )?;
                 let body = UpdateLdapConfigRequest {
                     name,
                     server_url,
@@ -419,6 +475,7 @@ impl SsoUpdateCommand {
                 issuer_url,
                 client_id,
                 client_secret,
+                client_secret_stdin,
                 auto_create_users,
                 scope,
                 allow_legacy_rsa_keys,
@@ -426,6 +483,15 @@ impl SsoUpdateCommand {
                 pkce_enabled,
                 is_enabled,
             } => {
+                // No prompt fallback on update: an omitted secret means
+                // "keep the existing one".
+                let client_secret = resolve_secret(
+                    client_secret,
+                    client_secret_stdin,
+                    "--client-secret",
+                    None,
+                    global.no_input,
+                )?;
                 let body = UpdateOidcConfigRequest {
                     name,
                     issuer_url,
@@ -581,18 +647,9 @@ async fn create_ldap(
     use_starttls: bool,
     global: &GlobalArgs,
 ) -> Result<()> {
-    // If bind_dn is provided without bind_password, prompt interactively
-    let bind_password = match (bind_dn, bind_password) {
-        (Some(_), None) if !global.no_input => {
-            let pw = dialoguer::Password::new()
-                .with_prompt("LDAP bind password")
-                .interact()
-                .map_err(|e| AkError::ConfigError(format!("Failed to read password: {e}")))?;
-            Some(pw)
-        }
-        (_, Some(pw)) => Some(pw.to_string()),
-        _ => None,
-    };
+    // Secret resolution (prompt/stdin/env) happens at the dispatch layer via
+    // `resolve_secret`; by the time we get here the password is final.
+    let bind_password = bind_password.map(|s| s.to_string());
 
     let client = client_for(global)?;
     let spinner = output::spinner("Creating LDAP provider...");
@@ -643,22 +700,15 @@ async fn create_oidc(
     auto_create_users: bool,
     global: &GlobalArgs,
 ) -> Result<()> {
-    let client_secret = match client_secret {
-        Some(s) => s,
-        None => {
-            if global.no_input {
-                return Err(AkError::ConfigError(
-                    "OIDC client secret is required. Provide --client-secret or remove --no-input."
-                        .to_string(),
-                )
-                .into());
-            }
-            dialoguer::Password::new()
-                .with_prompt("OIDC client secret")
-                .interact()
-                .map_err(|e| AkError::ConfigError(format!("Failed to read secret: {e}")))?
-        }
-    };
+    // Secret resolution (prompt/stdin/env) happens at the dispatch layer via
+    // `resolve_secret`; here the secret only needs to be present.
+    let client_secret = client_secret.ok_or_else(|| {
+        AkError::ConfigError(
+            "OIDC client secret is required. Provide --client-secret, pipe it to \
+             --client-secret-stdin, or set AK_SSO_CLIENT_SECRET."
+                .to_string(),
+        )
+    })?;
 
     let client = client_for(global)?;
     let spinner = output::spinner("Creating OIDC provider...");
@@ -1411,6 +1461,7 @@ mod tests {
                     user_base_dn,
                     bind_dn,
                     bind_password,
+                    bind_password_stdin,
                     use_starttls,
                 },
         } = cli.command
@@ -1420,7 +1471,39 @@ mod tests {
             assert_eq!(user_base_dn, "ou=users,dc=corp");
             assert!(bind_dn.is_none());
             assert!(bind_password.is_none());
+            assert!(!bind_password_stdin);
             assert!(!use_starttls);
+        } else {
+            panic!("Expected Create Ldap");
+        }
+    }
+
+    #[test]
+    fn parse_create_ldap_bind_password_stdin() {
+        let cli = parse(&[
+            "test",
+            "create",
+            "ldap",
+            "corp-ldap",
+            "--server-url",
+            "ldaps://ldap.corp.com",
+            "--user-base-dn",
+            "ou=users,dc=corp",
+            "--bind-dn",
+            "cn=admin,dc=corp",
+            "--bind-password-stdin",
+        ]);
+        if let SsoCommand::Create {
+            command:
+                SsoCreateCommand::Ldap {
+                    bind_password,
+                    bind_password_stdin,
+                    ..
+                },
+        } = cli.command
+        {
+            assert!(bind_password.is_none());
+            assert!(bind_password_stdin);
         } else {
             panic!("Expected Create Ldap");
         }
@@ -1484,6 +1567,7 @@ mod tests {
                     issuer_url,
                     client_id,
                     client_secret,
+                    client_secret_stdin,
                     auto_create_users,
                 },
         } = cli.command
@@ -1492,9 +1576,91 @@ mod tests {
             assert_eq!(issuer_url, "https://company.okta.com");
             assert_eq!(client_id, "abc123");
             assert_eq!(client_secret.unwrap(), "secret456");
+            assert!(!client_secret_stdin);
             assert!(!auto_create_users);
         } else {
             panic!("Expected Create Oidc");
+        }
+    }
+
+    #[test]
+    fn parse_create_oidc_client_secret_stdin() {
+        let cli = parse(&[
+            "test",
+            "create",
+            "oidc",
+            "okta-sso",
+            "--issuer-url",
+            "https://company.okta.com",
+            "--client-id",
+            "abc123",
+            "--client-secret-stdin",
+        ]);
+        if let SsoCommand::Create {
+            command:
+                SsoCreateCommand::Oidc {
+                    client_secret,
+                    client_secret_stdin,
+                    ..
+                },
+        } = cli.command
+        {
+            assert!(client_secret.is_none());
+            assert!(client_secret_stdin);
+        } else {
+            panic!("Expected Create Oidc");
+        }
+    }
+
+    #[test]
+    fn parse_update_oidc_client_secret_stdin() {
+        let cli = parse(&[
+            "test",
+            "update",
+            "oidc",
+            "00000000-0000-0000-0000-000000000001",
+            "--client-secret-stdin",
+        ]);
+        if let SsoCommand::Update { command } = cli.command {
+            if let SsoUpdateCommand::Oidc {
+                client_secret,
+                client_secret_stdin,
+                ..
+            } = *command
+            {
+                assert!(client_secret.is_none());
+                assert!(client_secret_stdin);
+            } else {
+                panic!("Expected Update Oidc");
+            }
+        } else {
+            panic!("Expected Update");
+        }
+    }
+
+    #[test]
+    fn parse_update_ldap_bind_password_stdin() {
+        let cli = parse(&[
+            "test",
+            "update",
+            "ldap",
+            "00000000-0000-0000-0000-000000000001",
+            "--bind-password-stdin",
+        ]);
+        if let SsoCommand::Update { command } = cli.command {
+            if let SsoUpdateCommand::Ldap {
+                bind_password,
+                bind_password_stdin,
+                ..
+            } = *command
+            {
+                assert!(bind_password.is_none());
+                assert!(bind_password_stdin);
+            } else {
+                panic!("Expected Update Ldap");
+            }
+        } else {
+            panic!("Expected Update");
         }
     }
 

--- a/src/commands/webhook.rs
+++ b/src/commands/webhook.rs
@@ -8,7 +8,8 @@ use serde_json::Value;
 
 use super::client::client_for;
 use super::helpers::{
-    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, sdk_err, short_id,
+    confirm_action, emit_mutation, new_table, parse_optional_uuid, parse_uuid, resolve_secret,
+    sdk_err, short_id,
 };
 use crate::cli::GlobalArgs;
 use crate::output::{self, OutputFormat};
@@ -45,9 +46,14 @@ pub enum WebhookCommand {
         #[arg(long, value_delimiter = ',', required = true)]
         events: Vec<String>,
 
-        /// Webhook signing secret
-        #[arg(long)]
+        /// Webhook signing secret (omit to be prompted, or pipe it to stdin)
+        #[arg(long, env = "AK_WEBHOOK_SECRET", hide_env_values = true)]
         secret: Option<String>,
+
+        /// Read the signing secret from stdin (avoids exposing it on the
+        /// command line)
+        #[arg(long)]
+        secret_stdin: bool,
 
         /// Scope webhook to a specific repository
         #[arg(long)]
@@ -122,8 +128,18 @@ impl WebhookCommand {
                 url,
                 events,
                 secret,
+                secret_stdin,
                 repo,
             } => {
+                // Resolve the signing secret off the command line: prompt on
+                // a TTY, or read piped stdin. Empty input keeps it unset.
+                let secret = resolve_secret(
+                    secret,
+                    secret_stdin,
+                    "--secret",
+                    Some("Webhook signing secret (leave empty for none)"),
+                    global.no_input,
+                )?;
                 create_webhook(
                     &name,
                     &url,
@@ -771,6 +787,7 @@ mod tests {
             url,
             events,
             secret,
+            secret_stdin,
             repo,
         } = cli.command
         {
@@ -778,7 +795,33 @@ mod tests {
             assert_eq!(url, "https://ci.example.com/hook");
             assert_eq!(events, vec!["artifact.pushed"]);
             assert!(secret.is_none());
+            assert!(!secret_stdin);
             assert!(repo.is_none());
+        } else {
+            panic!("Expected Create");
+        }
+    }
+
+    #[test]
+    fn parse_create_secret_stdin() {
+        let cli = parse(&[
+            "test",
+            "create",
+            "deploy-hook",
+            "--url",
+            "https://ci.example.com/hook",
+            "--events",
+            "artifact.pushed",
+            "--secret-stdin",
+        ]);
+        if let WebhookCommand::Create {
+            secret,
+            secret_stdin,
+            ..
+        } = cli.command
+        {
+            assert!(secret.is_none());
+            assert!(secret_stdin);
         } else {
             panic!("Expected Create");
         }
@@ -825,6 +868,7 @@ mod tests {
             url,
             events,
             secret,
+            secret_stdin,
             repo,
         } = cli.command
         {
@@ -832,6 +876,7 @@ mod tests {
             assert_eq!(url, "https://ci.example.com/hook");
             assert_eq!(events.len(), 2);
             assert_eq!(secret.unwrap(), "my-secret");
+            assert!(!secret_stdin);
             assert!(repo.is_some());
         } else {
             panic!("Expected Create with full args");


### PR DESCRIPTION
## Summary

Closes #137

Secret-valued options could only be supplied as plain command-line values, which leak into shell history and process listings. This adds safer input paths for every such option while keeping the existing value flags fully backward compatible, mirroring the pattern already used by `ak repo upstream-auth`.

All resolution goes through a new shared helper, `commands::helpers::resolve_secret`, with this precedence:

1. `--<flag>-stdin` — read the secret from stdin (for CI/scripts)
2. explicit `--<flag> <value>` or its env-var default — unchanged behavior; a soft warning on stderr nudges toward the safer forms when the value is visibly on argv
3. flag omitted, stdin piped/redirected — read the secret from stdin
4. flag omitted, stdin is a TTY, no `--no-input` — interactive no-echo prompt (empty input = no secret)
5. otherwise — unset (previous behavior)

Per command:

| Option | New stdin switch | Env default | Prompt when omitted |
|---|---|---|---|
| `import source add --password` | `--password-stdin` | `AK_IMPORT_PASSWORD` | yes (basic_auth) |
| `import source add --token` | `--token-stdin` | `AK_IMPORT_TOKEN` | yes (api_token) |
| `webhook create --secret` | `--secret-stdin` | `AK_WEBHOOK_SECRET` | yes (empty = none) |
| `auth ci-exchange --jwt` | `--jwt-stdin` | `AK_CI_JWT` (existing) | yes |
| `sso create oidc --client-secret` | `--client-secret-stdin` | `AK_SSO_CLIENT_SECRET` | yes (existing, kept) |
| `sso create ldap --bind-password` | `--bind-password-stdin` | `AK_LDAP_BIND_PASSWORD` | when `--bind-dn` given (existing, kept) |
| `sso update oidc --client-secret` | `--client-secret-stdin` | — | no (omitted = keep current) |
| `sso update ldap --bind-password` | `--bind-password-stdin` | — | no (omitted = keep current) |

The helper acquires the stdin reader lazily so the interactive prompt (which also reads stdin) cannot deadlock against a held `StdinLock`.

## Test Checklist

- [x] Unit tests for `resolve_secret` precedence (stdin switch, trimming, empty-input-means-none, piped read, `--no-input`, no-prompt update mode)
- [x] Parse tests for every new `--*-stdin` switch (import, webhook, auth, sso create/update)
- [x] `cargo fmt --check`, `cargo clippy --workspace -- -D warnings -A dead_code`, `cargo test --workspace` (2026 passed), `cargo build --release` all clean
- [x] Verified against a live backend: piped/`--*-stdin`/env/prompt paths for `import source add` and `webhook create`; `sso create/update oidc --client-secret-stdin`; `auth ci-exchange --jwt-stdin`; explicit value flags unchanged (plus stderr warning); `--no-input` never prompts or hangs

## API Changes

None (CLI-only). New optional CLI switches and env-var defaults; existing invocations behave identically.
