### PR TITLE
ci: add Windows to build matrix; align Dockerfile Rust base with MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-slim AS builder
+FROM rust:1.88-slim AS builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
## Summary

Two small CI/build-correctness fixes:

- **Dockerfile**: bump the builder base image from `rust:1.85-slim` to `rust:1.88-slim` so it matches the crate's MSRV (`rust-version = "1.88.0"` in Cargo.toml). Docker builds previously used a toolchain older than the declared minimum and would fail to compile.
- **CI build matrix**: add `windows-latest` to the `build` job matrix in `.github/workflows/ci.yml`. The release workflow ships `ak-windows-amd64.exe` (`x86_64-pc-windows-msvc`), but CI never compiled the crate on Windows, so the shipped binary was untested pre-release. The keyring dependency already enables the `windows-native` feature and all file-permission code is `#[cfg(unix)]`-gated, so no source changes were needed.

## Test Checklist

- [x] `cargo build --workspace` (Linux)
- [x] `cargo test --workspace` (Linux)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings -A dead_code`
- [x] ci.yml YAML validates; existing ubuntu/macos matrix entries unchanged
- [x] `rust:1.88-slim` tag verified to exist on Docker Hub
- [x] Windows CI build job green on this PR (Build (windows-latest) passed, 10m53s, no cfg-gating or source changes required)

Closes #68
Closes #69