### PR TITLE
feat(cli): harden credential file writes, pull overwrite safety, doctor proxy visibility

### DIFF
--- a/src/commands/artifact.rs
+++ b/src/commands/artifact.rs
@@ -50,6 +50,10 @@ pub enum ArtifactCommand {
         /// Output file path (defaults to artifact filename)
         #[arg(short, long)]
         output: Option<String>,
+
+        /// Overwrite the output file if it already exists
+        #[arg(long)]
+        force: bool,
     },
 
     /// List artifacts in a repository
@@ -162,9 +166,12 @@ impl ArtifactCommand {
                 )
                 .await
             }
-            Self::Pull { repo, path, output } => {
-                pull(&repo, &path, output.as_deref(), global).await
-            }
+            Self::Pull {
+                repo,
+                path,
+                output,
+                force,
+            } => pull(&repo, &path, output.as_deref(), force, global).await,
             Self::List {
                 repo,
                 search,
@@ -383,10 +390,57 @@ async fn single_put_upload(
         .map_err(|e| AkError::ServerError(format!("Invalid upload response: {e}")).into())
 }
 
+/// Open the pull output file for writing.
+///
+/// Always creates the file with `create_new` (`O_CREAT | O_EXCL`), which
+/// refuses to follow an existing symlink and never truncates existing data.
+/// Without `--force`, an existing file (or symlink) at the path is an error;
+/// with `--force`, the existing entry is removed first and the output is
+/// recreated as a regular file, so the download never writes through a
+/// symlink to some other location.
+async fn open_pull_output(out_path: &Path, force: bool) -> Result<tokio::fs::File> {
+    if force {
+        match tokio::fs::remove_file(out_path).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(AkError::ConfigError(format!(
+                    "Cannot overwrite '{}': {e}",
+                    out_path.display()
+                ))
+                .into());
+            }
+        }
+    }
+
+    tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(out_path)
+        .await
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                AkError::ConfigError(format!(
+                    "Output file '{}' already exists. Pass --force to overwrite it, \
+                     or use --output to choose a different path.",
+                    out_path.display()
+                ))
+                .into()
+            } else {
+                AkError::ConfigError(format!(
+                    "Cannot create output file '{}': {e}",
+                    out_path.display()
+                ))
+                .into()
+            }
+        })
+}
+
 async fn pull(
     repo: &str,
     artifact_path: &str,
     output: Option<&str>,
+    force: bool,
     global: &GlobalArgs,
 ) -> Result<()> {
     let client = client_for(global)?;
@@ -399,28 +453,56 @@ async fn pull(
         PathBuf::from(filename)
     });
 
+    // Fail fast (before the download) when the destination already exists.
+    let mut file = open_pull_output(&out_path, force).await?;
+
     let spinner = output::spinner(&format!("Downloading {artifact_path}..."));
 
-    let resp = client
+    let resp = match client
         .download_artifact()
         .key(repo)
         .path(artifact_path)
         .send()
         .await
-        .map_err(|e| AkError::ServerError(format!("Download failed: {e}")))?;
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            spinner.finish_and_clear();
+            // Don't leave an empty placeholder file behind on failure.
+            drop(file);
+            let _ = tokio::fs::remove_file(&out_path).await;
+            return Err(AkError::ServerError(format!("Download failed: {e}")).into());
+        }
+    };
 
     spinner.finish_and_clear();
-
-    let mut file = tokio::fs::File::create(&out_path).await.into_diagnostic()?;
     let mut stream = resp.into_inner();
     let mut total_bytes: u64 = 0;
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| AkError::ServerError(format!("Download error: {e}")))?;
-        tokio::io::AsyncWriteExt::write_all(&mut file, &chunk)
-            .await
-            .into_diagnostic()?;
-        total_bytes += chunk.len() as u64;
+    let copy_result: Result<()> = async {
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| AkError::ServerError(format!("Download error: {e}")))?;
+            tokio::io::AsyncWriteExt::write_all(&mut file, &chunk)
+                .await
+                .into_diagnostic()?;
+            total_bytes += chunk.len() as u64;
+        }
+        Ok(())
     }
+    .await;
+
+    if let Err(e) = copy_result {
+        // Remove the partial download so a retry doesn't require --force.
+        drop(file);
+        let _ = tokio::fs::remove_file(&out_path).await;
+        return Err(e);
+    }
+
+    // tokio::fs::File does not flush pending writes on drop; flush explicitly
+    // so the file is complete before success is reported.
+    tokio::io::AsyncWriteExt::flush(&mut file)
+        .await
+        .into_diagnostic()?;
+    drop(file);
 
     eprintln!(
         "Downloaded {}:{} -> {} ({})",
@@ -965,6 +1047,11 @@ async fn cross_instance_copy(
             .into_diagnostic()?;
         total_bytes += chunk.len() as u64;
     }
+    // tokio::fs::File does not flush pending writes on drop; flush before the
+    // re-open below so the upload doesn't read a truncated file.
+    tokio::io::AsyncWriteExt::flush(&mut file)
+        .await
+        .into_diagnostic()?;
     drop(file);
 
     let (dst_repo, dst_path) = match destination.split_once('/') {
@@ -1195,10 +1282,17 @@ mod tests {
     #[test]
     fn parse_pull() {
         let cli = parse(&["test", "pull", "my-repo", "org/pkg/1.0/pkg.jar"]);
-        if let ArtifactCommand::Pull { repo, path, output } = cli.command {
+        if let ArtifactCommand::Pull {
+            repo,
+            path,
+            output,
+            force,
+        } = cli.command
+        {
             assert_eq!(repo, "my-repo");
             assert_eq!(path, "org/pkg/1.0/pkg.jar");
             assert!(output.is_none());
+            assert!(!force, "force must default to off");
         } else {
             panic!("Expected ArtifactCommand::Pull");
         }
@@ -1214,10 +1308,23 @@ mod tests {
             "-o",
             "local-pkg.jar",
         ]);
-        if let ArtifactCommand::Pull { repo, path, output } = cli.command {
+        if let ArtifactCommand::Pull {
+            repo, path, output, ..
+        } = cli.command
+        {
             assert_eq!(repo, "my-repo");
             assert_eq!(path, "org/pkg/1.0/pkg.jar");
             assert_eq!(output.as_deref(), Some("local-pkg.jar"));
+        } else {
+            panic!("Expected ArtifactCommand::Pull");
+        }
+    }
+
+    #[test]
+    fn parse_pull_with_force() {
+        let cli = parse(&["test", "pull", "my-repo", "path/to/file", "--force"]);
+        if let ArtifactCommand::Pull { force, .. } = cli.command {
+            assert!(force);
         } else {
             panic!("Expected ArtifactCommand::Pull");
         }
@@ -2211,6 +2318,210 @@ mod tests {
         assert!(result.is_err(), "404 must remain an error");
         let msg = format!("{:?}", result.unwrap_err());
         assert!(msg.contains("404"), "error should carry the status: {msg}");
+        crate::test_utils::teardown_env();
+    }
+
+    // ---- open_pull_output (overwrite / symlink safety) ----
+
+    #[tokio::test]
+    async fn pull_output_fresh_path_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("new-file.bin");
+        let file = open_pull_output(&out, false).await;
+        assert!(file.is_ok());
+        assert!(out.exists());
+    }
+
+    #[tokio::test]
+    async fn pull_output_existing_file_refused_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("existing.bin");
+        std::fs::write(&out, b"precious data").unwrap();
+
+        let result = open_pull_output(&out, false).await;
+        assert!(result.is_err());
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            msg.contains("--force"),
+            "error should mention --force: {msg}"
+        );
+        // The existing file must be untouched.
+        assert_eq!(std::fs::read(&out).unwrap(), b"precious data");
+    }
+
+    #[tokio::test]
+    async fn pull_output_existing_file_overwritten_with_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("existing.bin");
+        std::fs::write(&out, b"old contents").unwrap();
+
+        let mut file = open_pull_output(&out, true).await.unwrap();
+        tokio::io::AsyncWriteExt::write_all(&mut file, b"new")
+            .await
+            .unwrap();
+        tokio::io::AsyncWriteExt::flush(&mut file).await.unwrap();
+        drop(file);
+
+        assert_eq!(std::fs::read(&out).unwrap(), b"new");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pull_output_symlink_refused_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, b"linked target").unwrap();
+        let link = dir.path().join("link.bin");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let result = open_pull_output(&link, false).await;
+        assert!(result.is_err(), "must not write through a symlink");
+        assert_eq!(
+            std::fs::read(&target).unwrap(),
+            b"linked target",
+            "symlink target must be untouched"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pull_output_force_replaces_symlink_not_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, b"linked target").unwrap();
+        let link = dir.path().join("link.bin");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let mut file = open_pull_output(&link, true).await.unwrap();
+        tokio::io::AsyncWriteExt::write_all(&mut file, b"downloaded")
+            .await
+            .unwrap();
+        tokio::io::AsyncWriteExt::flush(&mut file).await.unwrap();
+        drop(file);
+
+        // The symlink itself was replaced by a regular file...
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+        assert!(meta.file_type().is_file(), "output must be a regular file");
+        assert_eq!(std::fs::read(&link).unwrap(), b"downloaded");
+        // ...and the old target was not written through.
+        assert_eq!(std::fs::read(&target).unwrap(), b"linked target");
+    }
+
+    // ---- pull handler (wiremock) ----
+
+    #[tokio::test]
+    async fn handler_pull_downloads_to_fresh_path() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex("^/api/v1/repositories/.+/download/.+$"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"artifact bytes".to_vec()))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("pulled.bin");
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = pull(
+            "my-repo",
+            "path/to/pulled.bin",
+            Some(&out.to_string_lossy()),
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok(), "pull to fresh path must work: {result:?}");
+        assert_eq!(std::fs::read(&out).unwrap(), b"artifact bytes");
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_pull_refuses_existing_output_without_force() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        // No mock mounted: the request must never be sent — the pull should
+        // fail fast on the local file check (wiremock would 404 anyway).
+        drop(server);
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("existing.bin");
+        std::fs::write(&out, b"do not clobber").unwrap();
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = pull(
+            "my-repo",
+            "path/to/existing.bin",
+            Some(&out.to_string_lossy()),
+            false,
+            &global,
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "existing output without --force must error"
+        );
+        assert_eq!(std::fs::read(&out).unwrap(), b"do not clobber");
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_pull_overwrites_existing_output_with_force() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex("^/api/v1/repositories/.+/download/.+$"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"fresh copy".to_vec()))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("existing.bin");
+        std::fs::write(&out, b"stale copy").unwrap();
+
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = pull(
+            "my-repo",
+            "path/to/existing.bin",
+            Some(&out.to_string_lossy()),
+            true,
+            &global,
+        )
+        .await;
+        assert!(result.is_ok(), "--force overwrite must work: {result:?}");
+        assert_eq!(std::fs::read(&out).unwrap(), b"fresh copy");
+        crate::test_utils::teardown_env();
+    }
+
+    #[tokio::test]
+    async fn handler_pull_failed_download_removes_placeholder() {
+        let (server, tmp) = crate::test_utils::mock_setup().await;
+        let _guard = crate::test_utils::setup_env(&tmp);
+
+        Mock::given(method("GET"))
+            .and(path_regex("^/api/v1/repositories/.+/download/.+$"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({"error": "not found"})))
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("missing.bin");
+        let global = crate::test_utils::test_global(OutputFormat::Quiet);
+        let result = pull(
+            "my-repo",
+            "path/to/missing.bin",
+            Some(&out.to_string_lossy()),
+            false,
+            &global,
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(
+            !out.exists(),
+            "failed pull must not leave an empty placeholder file"
+        );
         crate::test_utils::teardown_env();
     }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -370,9 +370,56 @@ fn check_docker_config(home: &std::path::Path, instance_urls: &[&str], diag: &mu
 // CLI info
 // ---------------------------------------------------------------------------
 
+/// Proxy-related environment variables honored by the HTTP client (reqwest).
+const PROXY_ENV_VARS: &[&str] = &[
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+];
+
+/// Redact the userinfo part of a proxy URL (e.g. `http://user:pass@host`)
+/// so credentials embedded in proxy settings are not echoed to the terminal.
+fn redact_proxy_value(value: &str) -> String {
+    if let Some(at) = value.rfind('@') {
+        let scheme_end = value.find("://").map(|i| i + 3).unwrap_or(0);
+        if at > scheme_end {
+            return format!("{}***@{}", &value[..scheme_end], &value[at + 1..]);
+        }
+    }
+    value.to_string()
+}
+
+/// Surface any active proxy configuration so users can tell when CLI traffic
+/// is being routed through an intermediary.
+fn check_proxy_env(diag: &mut DiagResult) {
+    let mut found = false;
+    for var in PROXY_ENV_VARS {
+        if let Ok(value) = std::env::var(var) {
+            if value.is_empty() {
+                continue;
+            }
+            found = true;
+            diag.skip(&format!(
+                "Proxy: {var}={} (requests are routed through this proxy)",
+                redact_proxy_value(&value)
+            ));
+        }
+    }
+    if !found {
+        diag.skip("No proxy environment variables set");
+    }
+}
+
 fn check_cli(diag: &mut DiagResult) {
     let version = env!("CARGO_PKG_VERSION");
     diag.pass(&format!("CLI version: {version}"));
+
+    check_proxy_env(diag);
 
     match crate::config::config_dir() {
         Ok(dir) => {
@@ -570,6 +617,40 @@ mod tests {
         // base64url("not json") = bm90IGpzb24
         let token = "header.bm90IGpzb24.signature";
         assert_eq!(decode_jwt_expiry(token), None);
+    }
+
+    // ---- redact_proxy_value ----
+
+    #[test]
+    fn redact_proxy_plain_url_unchanged() {
+        assert_eq!(
+            redact_proxy_value("http://proxy.corp:3128"),
+            "http://proxy.corp:3128"
+        );
+    }
+
+    #[test]
+    fn redact_proxy_credentials_hidden() {
+        assert_eq!(
+            redact_proxy_value("http://user:secret@proxy.corp:3128"),
+            "http://***@proxy.corp:3128"
+        );
+    }
+
+    #[test]
+    fn redact_proxy_no_scheme_with_credentials() {
+        assert_eq!(
+            redact_proxy_value("user:secret@proxy.corp:3128"),
+            "***@proxy.corp:3128"
+        );
+    }
+
+    #[test]
+    fn redact_proxy_no_proxy_list_unchanged() {
+        assert_eq!(
+            redact_proxy_value("localhost,127.0.0.1,.internal"),
+            "localhost,127.0.0.1,.internal"
+        );
     }
 
     // ---- print_summary ----

--- a/src/config/credentials.rs
+++ b/src/config/credentials.rs
@@ -26,11 +26,25 @@ pub fn store_credential(instance: &str, cred: &StoredCredential) -> Result<()> {
         .is_ok();
 
     if keychain_ok {
+        // The keyring is now the source of truth for this instance. Purge any
+        // stale plaintext file-fallback entry left behind by a prior headless
+        // run so a rotated/old token doesn't linger on disk. Best-effort: the
+        // credential was stored successfully either way.
+        purge_file_fallback(instance);
         return Ok(());
     }
 
     eprintln!("Keychain unavailable, using file fallback");
     store_to_file(instance, &json)
+}
+
+/// Best-effort removal of a file-fallback credential entry.
+///
+/// Used after a successful keyring write so a superseded token doesn't remain
+/// readable in `credentials.json`. Errors (e.g. unreadable file) are ignored;
+/// a missing file or missing entry is not an error to begin with.
+fn purge_file_fallback(instance: &str) {
+    let _ = delete_from_file(instance);
 }
 
 /// Retrieve a credential for a given instance.
@@ -98,14 +112,9 @@ fn save_all_file_creds(creds: &HashMap<String, String>) -> Result<()> {
         }
     }
     let content = serde_json::to_string_pretty(creds).into_diagnostic()?;
-    fs::write(&path, content).into_diagnostic()?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-            .into_diagnostic()?;
-    }
-    Ok(())
+    // Atomic write with owner-only permissions from creation: the plaintext
+    // token file must never be observable with broader permissions.
+    super::write_private_atomic(&path, &content)
 }
 
 fn store_to_file(instance: &str, json: &str) -> Result<()> {
@@ -226,6 +235,73 @@ mod tests {
             let loaded = load_from_file("inst").unwrap().unwrap();
             assert!(loaded.contains("\"new\""));
             assert!(!loaded.contains("\"old\""));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn credentials_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        with_temp_config(|| {
+            store_to_file("inst", r#"{"access_token":"t","refresh_token":null}"#).unwrap();
+            let path = credentials_path().unwrap();
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "credentials.json should be 0600, got {mode:o}");
+        });
+    }
+
+    #[test]
+    fn credentials_write_leaves_no_temp_files() {
+        with_temp_config(|| {
+            store_to_file("a", r#"{"access_token":"1","refresh_token":null}"#).unwrap();
+            store_to_file("b", r#"{"access_token":"2","refresh_token":null}"#).unwrap();
+            let dir = super::super::config_dir().unwrap();
+            let entries: Vec<_> = std::fs::read_dir(&dir)
+                .unwrap()
+                .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+                .collect();
+            assert_eq!(entries, vec!["credentials.json"]);
+        });
+    }
+
+    #[test]
+    fn purge_file_fallback_removes_stale_entry() {
+        with_temp_config(|| {
+            let json = r#"{"access_token":"stale-token","refresh_token":null}"#;
+            store_to_file("rotated-inst", json).unwrap();
+
+            purge_file_fallback("rotated-inst");
+
+            let loaded = load_from_file("rotated-inst").unwrap();
+            assert!(loaded.is_none(), "stale file-fallback entry must be purged");
+            // The raw file must no longer contain the old token bytes.
+            let path = credentials_path().unwrap();
+            if path.exists() {
+                let content = std::fs::read_to_string(&path).unwrap();
+                assert!(!content.contains("stale-token"));
+            }
+        });
+    }
+
+    #[test]
+    fn purge_file_fallback_missing_file_is_noop() {
+        with_temp_config(|| {
+            // No credentials.json exists at all; must not panic or create one.
+            purge_file_fallback("nonexistent");
+            assert!(!credentials_path().unwrap().exists());
+        });
+    }
+
+    #[test]
+    fn purge_file_fallback_keeps_other_instances() {
+        with_temp_config(|| {
+            store_to_file("keep", r#"{"access_token":"k","refresh_token":null}"#).unwrap();
+            store_to_file("purge", r#"{"access_token":"p","refresh_token":null}"#).unwrap();
+
+            purge_file_fallback("purge");
+
+            assert!(load_from_file("purge").unwrap().is_none());
+            assert!(load_from_file("keep").unwrap().is_some());
         });
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -75,14 +75,7 @@ impl AppConfig {
             }
         }
         let content = toml::to_string_pretty(self).into_diagnostic()?;
-        std::fs::write(&path, content).into_diagnostic()?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-                .into_diagnostic()?;
-        }
-        Ok(())
+        write_private_atomic(&path, &content)
     }
 
     /// Get the active instance config, resolving from flag → env → default.
@@ -101,6 +94,45 @@ impl AppConfig {
 
         Ok((name, instance))
     }
+}
+
+/// Write `content` to `path` without the file ever being readable by other
+/// users, and without readers observing a partially written file.
+///
+/// The content is first written to a uniquely named temporary file created in
+/// the same directory as `path` (so the final rename stays on one filesystem
+/// and is atomic), then renamed over `path`, replacing any previous version.
+///
+/// On Unix the temporary file is created with mode `0o600` (via `O_CREAT |
+/// O_EXCL`), so at no point does a file with the secret content exist with
+/// group/world-readable permissions — unlike a plain `fs::write` followed by
+/// `set_permissions`, which leaves a umask-dependent race window. On other
+/// platforms the file inherits the default ACLs of the (already restricted)
+/// parent directory.
+pub(crate) fn write_private_atomic(path: &std::path::Path, content: &str) -> Result<()> {
+    use std::io::Write;
+
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(".ak-write-").suffix(".tmp");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(std::fs::Permissions::from_mode(0o600));
+    }
+
+    let mut tmp = builder.tempfile_in(&parent).into_diagnostic()?;
+    tmp.write_all(content.as_bytes()).into_diagnostic()?;
+    tmp.as_file().sync_all().into_diagnostic()?;
+    // `persist` renames the temp file over `path`, atomically replacing any
+    // existing file; on failure the temp file is cleaned up.
+    tmp.persist(path)
+        .map_err(|e| AkError::ConfigError(format!("Failed to write {}: {}", path.display(), e)))?;
+    Ok(())
 }
 
 /// Returns the path to the config directory.
@@ -360,6 +392,75 @@ url = "https://test.com"
 
             let loaded = AppConfig::load().unwrap();
             assert_eq!(loaded.output_format, "yaml");
+        });
+    }
+
+    // ---- write_private_atomic ----
+
+    #[test]
+    fn write_private_atomic_creates_file_with_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.json");
+        write_private_atomic(&path, "top-secret").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "top-secret");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_atomic_sets_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.json");
+        write_private_atomic(&path, "token").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode & 0o077,
+            0,
+            "credential file must not be group/world accessible, got {mode:o}"
+        );
+        assert_eq!(mode, 0o600, "credential file should be 0600, got {mode:o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_atomic_overwrite_keeps_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.json");
+        // Simulate a pre-existing file with overly broad permissions.
+        std::fs::write(&path, "old").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_private_atomic(&path, "new").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "replaced file should be 0600, got {mode:o}");
+    }
+
+    #[test]
+    fn write_private_atomic_leaves_no_temp_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.json");
+        write_private_atomic(&path, "a").unwrap();
+        write_private_atomic(&path, "b").unwrap();
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(entries, vec!["secret.json"], "no temp files should remain");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_config_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        with_temp_config(|| {
+            let config = AppConfig::default();
+            config.save().unwrap();
+            let path = config_path().unwrap();
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "config.toml should be 0600, got {mode:o}");
         });
     }
 


### PR DESCRIPTION
Closes #140

## What

Four local file-handling hardening items in the CLI:

### 1. Atomic owner-only credential/config writes
`AppConfig::save` and the credentials file fallback previously did `fs::write(path)` followed by `set_permissions(0600)`, so the plaintext token/config file briefly existed with umask-dependent (potentially group/world-readable) permissions. Both now go through a shared `write_private_atomic` helper (`src/config/mod.rs`): the content is written to a uniquely named temp file created in the same directory — on Unix with mode `0600` from creation (`O_CREAT|O_EXCL`) — and then atomically renamed over the destination. The file is never observable with broader permissions or partially written. The `0700` parent-directory creation is preserved. Unix-specific bits are `#[cfg(unix)]`-gated; on other platforms the write is still atomic and inherits the directory ACLs (verified the crate compiles for `x86_64-pc-windows-gnu`).

### 2. Rotation residue purge
After a successful keyring store, any stale `credentials.json` file-fallback entry for the same instance from a prior headless run was left on disk (shadowed by keyring precedence, but still a plaintext copy of an old token). `store_credential` now best-effort deletes the file-fallback entry once the keyring write succeeds; a missing file or entry is a no-op and errors never fail the store.

### 3. `ak artifact pull` overwrite + symlink safety
The output file was opened with `File::create`, which silently truncates an existing file and writes through a symlink. Now:
- Without `--force`, an existing file (or symlink) at the output path is a clear error suggesting `--force` or `--output`, checked before the download starts. The existing file is untouched.
- New `--force` flag opts into overwrite. An existing symlink is removed and replaced by a regular file rather than written through.
- The output is always created with `create_new` (`O_CREAT|O_EXCL`), so the download never truncates existing data or follows a symlink.
- A failed download no longer leaves an empty/partial placeholder behind (so a retry doesn't need `--force`), and the file is flushed before success is reported (`tokio::fs::File` does not flush on drop). The same missing flush in cross-instance `copy`'s temp download is fixed.

Fresh-path pulls and `--output` to a new path behave exactly as before.

### 4. `ak doctor` proxy transparency
Doctor now lists any active `HTTP(S)_PROXY` / `ALL_PROXY` / `NO_PROXY` environment variables (the ones reqwest honors) so users can tell when CLI traffic is being routed through an intermediary. Credentials embedded in proxy URLs are redacted (`http://***@host:port`).

## Assessed, deferred

- **Response-size cap on non-download endpoints**: JSON responses are buffered fully in the generated (progenitor) SDK before deserialization, so a hostile server returning a huge body to `list`/`search` inflates CLI memory. A cap needs SDK/client-layer support and is not cheap from the CLI side; noted as follow-up in #140. The existing 30s request timeout bounds slow-drip but not memory.

## Testing

- New unit tests: atomic write creates/replaces with mode `0600` and leaves no temp files (asserted on both fresh write and overwrite of a `0644` file); config save is `0600`; purge removes only the target instance entry, is a no-op without a file, and keeps other instances; pull output refuses existing files without `--force` (error mentions `--force`, contents untouched), overwrites with `--force`, refuses symlinks without `--force` and replaces (not follows) them with `--force`; wiremock end-to-end pull tests for fresh path, refusal, forced overwrite, and placeholder cleanup on 404; proxy redaction cases.
- `cargo build`, `cargo build --release`, `cargo fmt --check`, `cargo clippy --workspace -- -D warnings -A dead_code`, `cargo test --workspace` (2078 passed) all clean; `cargo check --target x86_64-pc-windows-gnu` passes.
- Verified against a live v1.4.0 instance: pull to a fresh path and default-filename pull work; pulling onto an existing file without `--force` exits 1 and leaves the file untouched; `--force` overwrites; pulling onto a symlinked output exits 1 without touching the link target; CLI-written `config.toml` is `0600` in a `0700` directory; `ak doctor` shows `Proxy: HTTPS_PROXY=http://***@proxy.corp:3128` with a credentialed proxy URL set.