### PR TITLE
ci: sign release artifacts with cosign keyless signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,10 @@ jobs:
     name: Create Release
     needs: [build, completions, packages]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Required for keyless (Sigstore OIDC) signing with cosign.
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -236,18 +240,61 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      # Pinned to a cosign v2 release: cosign v3 changed keyless sign-blob to
+      # bundle-only output (--bundle), dropping the .sig/.pem flow used below.
+      - uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: "v2.6.3"
+
+      - name: Sign release artifacts (cosign keyless)
+        run: |
+          cd artifacts
+          for f in ak-linux-* ak-darwin-* ak-windows-* \
+                   ak-completions.tar.gz ak-man-pages.tar.gz \
+                   *.deb *.rpm; do
+            # Skip checksum files and anything already produced by signing.
+            case "$f" in
+              *.sha256|*.sig|*.pem) continue ;;
+            esac
+            [ -f "$f" ] || continue
+            cosign sign-blob --yes \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem" \
+              "$f"
+          done
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          body: |
+            ## Verifying signatures
+
+            All release artifacts are signed with [cosign](https://docs.sigstore.dev/cosign/signing/signing_with_blobs/)
+            (keyless, via the GitHub Actions OIDC identity). Each artifact has a
+            `.sig` (signature) and `.pem` (signing certificate) file. To verify a
+            download, e.g. `ak-linux-amd64`:
+
+            ```sh
+            cosign verify-blob \
+              --certificate ak-linux-amd64.pem \
+              --signature ak-linux-amd64.sig \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              ak-linux-amd64
+            ```
           files: |
             artifacts/ak-linux-*
             artifacts/ak-darwin-*
             artifacts/ak-windows-*
-            artifacts/ak-completions.tar.gz
-            artifacts/ak-man-pages.tar.gz
+            artifacts/ak-completions.tar.gz*
+            artifacts/ak-man-pages.tar.gz*
             artifacts/*.deb
+            artifacts/*.deb.sig
+            artifacts/*.deb.pem
             artifacts/*.rpm
+            artifacts/*.rpm.sig
+            artifacts/*.rpm.pem
 
   homebrew:
     name: Update Homebrew Tap

--- a/README.md
+++ b/README.md
@@ -50,7 +50,33 @@ Pre-built binaries for every platform are available on the [Releases](https://gi
 | macOS ARM64 (Apple Silicon) | `ak-darwin-arm64` |
 | Windows x86_64 | `ak-windows-amd64.exe` |
 
-Each binary includes a `.sha256` checksum file for verification.
+Each binary includes a `.sha256` checksum file for integrity verification.
+
+#### Verifying signatures
+
+Release artifacts are also signed with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/)
+using [Sigstore keyless signing](https://docs.sigstore.dev/cosign/signing/overview/) — the signing
+identity is the release workflow itself, authenticated via GitHub Actions OIDC, so there is no
+long-lived signing key that can leak. Every artifact is published with a `.sig` (signature) and
+`.pem` (signing certificate) file.
+
+To verify authenticity (not just integrity) of a download, e.g. `ak-linux-amd64` from release `vX.Y.Z`:
+
+```bash
+cosign verify-blob \
+  --certificate ak-linux-amd64.pem \
+  --signature ak-linux-amd64.sig \
+  --certificate-identity "https://github.com/artifact-keeper/artifact-keeper-cli/.github/workflows/release.yml@refs/tags/vX.Y.Z" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ak-linux-amd64
+```
+
+A successful verification prints `Verified OK`. The `--certificate-identity` value pins the exact
+workflow and tag that produced the signature; to accept any release tag from this repository's
+release workflow, pass
+`--certificate-identity-regexp '^https://github\.com/artifact-keeper/artifact-keeper-cli/\.github/workflows/release\.yml@refs/tags/v.*$'`
+instead. The same command works for the `.deb`/`.rpm` packages and the completions/man-page
+tarballs — substitute the file name.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Release artifacts currently ship with SHA256 checksums only — users can verify integrity but not authenticity. This adds cryptographic signatures to every release asset using [cosign keyless signing](https://docs.sigstore.dev/cosign/signing/overview/) (Sigstore), authenticated by the release workflow's GitHub Actions OIDC identity, so there is no long-lived signing key to manage or leak.

Closes #77

## Changes

**`.github/workflows/release.yml`** — `release` job:
- Job-level `permissions: contents: write, id-token: write` (the OIDC token grant required for keyless signing; other jobs keep the top-level `contents: write` only)
- `sigstore/cosign-installer@v3` pinned to `cosign-release: v2.6.3` — cosign v3 changed keyless `sign-blob` to bundle-only output (`--bundle`), which would break the `.sig`/`.pem` flow; v2 is still maintained (v2.6.3) and its detached-signature output is what most users' `verify-blob` invocations expect (v3 clients still verify these, with a deprecation notice)
- New signing step: after `download-artifact`, loops over all release assets (5 binaries, 2 tarballs, 2 deb, 2 rpm) and runs `cosign sign-blob --yes --output-signature <f>.sig --output-certificate <f>.pem <f>`, skipping `.sha256`/`.sig`/`.pem` files
- Release upload globs extended so each asset's `.sig` + `.pem` are published alongside it
- Release notes body now includes a ready-to-paste `cosign verify-blob` command with the correct `--certificate-identity` for the tag being released

**`README.md`** — new *Verifying signatures* subsection under GitHub Releases: full `cosign verify-blob --certificate ... --signature ... --certificate-identity ... --certificate-oidc-issuer https://token.actions.githubusercontent.com` walkthrough, plus the `--certificate-identity-regexp` variant for accepting any release tag.

## Validation

- `yaml.safe_load` passes on the modified workflow; job/step structure verified
- Dry-ran the signing loop against a dummy artifact set matching the real release layout (11 assets incl. `ak-windows-amd64.exe`, `ak_*_amd64.deb`, `ak-*.x86_64.rpm`): every asset signed exactly once, checksum/sig/pem files correctly skipped
- Verified every published file (asset + `.sig` + `.pem` + `.sha256`) matches exactly one release glob — no duplicate-upload collisions
- Validated the exact cosign flags against a real `cosign` v2.6.3 binary: keyless `sign-blob --yes --output-signature --output-certificate` passes flag validation and blocks only on OIDC token acquisition (ambient in Actions with `id-token: write`); a local-key `sign-blob`/`verify-blob` round trip on a dummy blob returns `Verified OK`
- Full keyless signing cannot be exercised outside GitHub Actions (requires the workflow OIDC token), so end-to-end confirmation lands with the first tagged release; existing build/completions/packages/homebrew/snap jobs are untouched