### PR TITLE
feat(cli): custom CA certificate support (--ca-cert / AK_CA_CERT)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ To regenerate: `cargo run -p xtask -- generate`
 | `AK_COLOR` | Color mode (auto/always/never) |
 | `AK_CONFIG_DIR` | Override config directory |
 | `AK_TOKEN` | API token (alternative to keychain) |
+| `AK_CA_CERT` | Path to a PEM file with additional root CA certificate(s) to trust (same as `--ca-cert`) |
 | `NO_COLOR` | Standard no-color flag |
 
 ## Git Conventions

--- a/README.md
+++ b/README.md
@@ -173,6 +173,25 @@ ak instance use prod
 ak repo list --instance staging
 ```
 
+## Custom CA Certificates
+
+For instances behind a private or enterprise Certificate Authority (internal
+registries, corporate TLS-inspection proxies), point the CLI at a PEM file
+containing the CA certificate — or a bundle with multiple certificates:
+
+```bash
+# Per invocation
+ak repo list --ca-cert /etc/ssl/corp-root-ca.pem
+
+# Or via environment variable (e.g. in CI)
+export AK_CA_CERT=/etc/ssl/corp-root-ca.pem
+ak artifact push my-repo ./build/output.tar.gz
+```
+
+The certificate(s) are **added** to the default trust store; TLS verification
+always remains enabled. There is intentionally no option to disable
+certificate verification — use `--ca-cert` to trust your private CA instead.
+
 ## Shell Completions
 
 ```bash
@@ -209,6 +228,7 @@ See the [CI/CD Integration Guide](https://artifactkeeper.com/docs/guides/ci-cd/)
 | `AK_INSTANCE` | Override default instance |
 | `AK_TOKEN` | API token (alternative to keychain) |
 | `AK_NO_INPUT` | Disable interactive prompts |
+| `AK_CA_CERT` | Path to a PEM file with additional root CA certificate(s) to trust (same as `--ca-cert`) |
 | `AK_COLOR` | Color mode (`auto`, `always`, `never`) |
 | `AK_CONFIG_DIR` | Override config directory |
 | `NO_COLOR` | Standard no-color flag |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,12 @@ pub struct Cli {
     #[arg(long, global = true, env = "AK_NO_INPUT")]
     pub no_input: bool,
 
+    /// Path to a PEM file with additional root CA certificate(s) to trust,
+    /// for instances behind a private/enterprise CA (may be a bundle with
+    /// multiple certificates). TLS verification remains enabled.
+    #[arg(long, global = true, env = "AK_CA_CERT", value_name = "PATH")]
+    pub ca_cert: Option<std::path::PathBuf>,
+
     /// Color output
     #[arg(long, global = true, default_value = "auto", env = "AK_COLOR")]
     pub color: ColorMode,
@@ -461,6 +467,13 @@ impl Cli {
             self.format.resolve(explicitly_set)
         };
 
+        // Record the custom CA path for all HTTP client construction sites
+        // (SDK wrappers, raw chunked-upload HTTP, doctor, TUI). The AK_CA_CERT
+        // env var is already folded into the flag by clap.
+        if let Some(ca_cert) = self.ca_cert {
+            crate::transport::set_ca_cert_override(ca_cert);
+        }
+
         let global = GlobalArgs {
             format,
             instance: self.instance,
@@ -537,6 +550,54 @@ mod tests {
 
     fn parse(args: &[&str]) -> std::result::Result<Cli, clap::Error> {
         Cli::try_parse_from(args)
+    }
+
+    // ---- Global --ca-cert flag ----
+
+    #[test]
+    fn parse_ca_cert_flag() {
+        let cli = parse(&["ak", "--ca-cert", "/etc/ssl/corp-ca.pem", "auth", "whoami"]).unwrap();
+        assert_eq!(
+            cli.ca_cert,
+            Some(std::path::PathBuf::from("/etc/ssl/corp-ca.pem"))
+        );
+    }
+
+    #[test]
+    fn parse_ca_cert_flag_is_global() {
+        // Global flags may appear after the subcommand.
+        let cli = parse(&["ak", "repo", "list", "--ca-cert", "bundle.pem"]).unwrap();
+        assert_eq!(cli.ca_cert, Some(std::path::PathBuf::from("bundle.pem")));
+    }
+
+    #[test]
+    fn parse_ca_cert_defaults_to_none() {
+        let _guard = crate::test_utils::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::remove_var("AK_CA_CERT") };
+        let cli = parse(&["ak", "auth", "whoami"]).unwrap();
+        assert_eq!(cli.ca_cert, None);
+    }
+
+    #[test]
+    fn parse_ca_cert_from_env() {
+        let _guard = crate::test_utils::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var("AK_CA_CERT", "/env/ca.pem") };
+        let cli = parse(&["ak", "auth", "whoami"]).unwrap();
+        assert_eq!(cli.ca_cert, Some(std::path::PathBuf::from("/env/ca.pem")));
+
+        // Explicit flag wins over the environment variable.
+        let cli = parse(&["ak", "--ca-cert", "/flag/ca.pem", "auth", "whoami"]).unwrap();
+        assert_eq!(cli.ca_cert, Some(std::path::PathBuf::from("/flag/ca.pem")));
+        unsafe { std::env::remove_var("AK_CA_CERT") };
+    }
+
+    #[test]
+    fn parse_ca_cert_requires_value() {
+        assert!(parse(&["ak", "--ca-cert"]).is_err());
     }
 
     // ---- Basic command parsing ----

--- a/src/commands/admin.rs
+++ b/src/commands/admin.rs
@@ -2359,7 +2359,7 @@ async fn install_plugin_zip(path: &str, global: &GlobalArgs) -> Result<()> {
     let form = reqwest::multipart::Form::new().part("file", part);
 
     let spinner = output::spinner("Installing plugin from ZIP...");
-    let http = reqwest::Client::new();
+    let http = super::client::raw_http_client()?;
     let resp = http
         .post(&url)
         .header(reqwest::header::AUTHORIZATION, auth_header)

--- a/src/commands/artifact.rs
+++ b/src/commands/artifact.rs
@@ -370,7 +370,7 @@ async fn single_put_upload(
         .extend(["api", "v1", "repositories", repo, "artifacts"])
         .extend(artifact_path.split('/'));
 
-    let resp = reqwest::Client::new()
+    let resp = super::client::raw_http_client()?
         .put(url)
         .header(reqwest::header::AUTHORIZATION, auth_header)
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 use miette::{IntoDiagnostic, Result};
 
-use super::client::{authenticated_client, build_client, client_for};
+use super::client::{anon_client, authenticated_client, build_client, client_for};
 use super::helpers::{parse_uuid, resolve_secret, sdk_err};
 use crate::cli::GlobalArgs;
 use crate::config::credentials::{
@@ -262,7 +262,7 @@ async fn login_with_password(instance_name: &str, instance: &InstanceConfig) -> 
         .interact()
         .into_diagnostic()?;
 
-    let anon_client = artifact_keeper_sdk::Client::new(&instance.url);
+    let anon_client = anon_client(&instance.url)?;
 
     let body = artifact_keeper_sdk::types::LoginRequest {
         username: username.clone(),
@@ -397,7 +397,7 @@ async fn verify_totp(code: &str, totp_token: &str, global: &GlobalArgs) -> Resul
     let (instance_name, instance_cfg) = config.resolve_instance(global.instance.as_deref())?;
     let instance_name = instance_name.to_string();
 
-    let anon_client = artifact_keeper_sdk::Client::new(&instance_cfg.url);
+    let anon_client = anon_client(&instance_cfg.url)?;
     let body = artifact_keeper_sdk::types::TotpVerifyRequest {
         code: code.to_string(),
         totp_token: totp_token.to_string(),
@@ -520,7 +520,7 @@ async fn setup_status(global: &GlobalArgs) -> Result<()> {
     let (_instance_name, instance_cfg) = config.resolve_instance(global.instance.as_deref())?;
 
     // Setup status is a pre-auth endpoint; no credentials required.
-    let client = artifact_keeper_sdk::Client::new(&instance_cfg.url);
+    let client = anon_client(&instance_cfg.url)?;
 
     let resp = client
         .setup_status()

--- a/src/commands/chunked_upload.rs
+++ b/src/commands/chunked_upload.rs
@@ -231,7 +231,7 @@ pub async fn chunked_upload(
     sha_spinner.finish_and_clear();
 
     // Step 2: Check for existing session to resume
-    let http = reqwest::Client::new();
+    let http = super::client::raw_http_client()?;
     let (session_id, server_chunk_size, chunks_completed) =
         match try_resume(&http, base_url, auth_header, file_path, &file_sha256).await? {
             Some((sid, cs, cc)) => {

--- a/src/commands/client.rs
+++ b/src/commands/client.rs
@@ -38,10 +38,11 @@ pub fn build_client(
             .map_err(|e| AkError::ConfigError(format!("Invalid token: {e}")))?,
     );
 
-    let http_client = reqwest::ClientBuilder::new()
+    let builder = reqwest::ClientBuilder::new()
         .default_headers(headers)
         .connect_timeout(Duration::from_secs(15))
-        .timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(30));
+    let http_client = transport::apply_custom_ca(builder)?
         .build()
         .into_diagnostic()?;
 
@@ -49,6 +50,37 @@ pub fn build_client(
         &instance.url,
         http_client,
     ))
+}
+
+/// Build an unauthenticated SDK client for a URL, honoring the custom CA
+/// configuration (`--ca-cert` / `AK_CA_CERT`).
+///
+/// Used by pre-auth flows (login, TOTP verify, setup status) that must work
+/// against instances behind a private CA before any credentials exist.
+pub fn anon_client(url: &str) -> Result<artifact_keeper_sdk::Client> {
+    let builder = reqwest::ClientBuilder::new()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(30));
+    let http_client = transport::apply_custom_ca(builder)?
+        .build()
+        .into_diagnostic()?;
+    Ok(artifact_keeper_sdk::Client::new_with_client(
+        url,
+        http_client,
+    ))
+}
+
+/// Build a plain reqwest client (no default auth headers) honoring the custom
+/// CA configuration, for raw HTTP calls made outside the SDK (chunked upload,
+/// SSE streams, multipart imports).
+///
+/// Deliberately sets no overall request timeout: these paths stream large
+/// bodies (uploads/downloads) where a fixed deadline would be wrong.
+pub fn raw_http_client() -> Result<reqwest::Client> {
+    let builder = reqwest::ClientBuilder::new().connect_timeout(Duration::from_secs(15));
+    transport::apply_custom_ca(builder)?
+        .build()
+        .into_diagnostic()
 }
 
 /// Resolve instance and build an authenticated client from GlobalArgs.
@@ -98,16 +130,7 @@ pub fn client_for_optional_auth(global: &GlobalArgs) -> Result<artifact_keeper_s
         return Ok(client);
     }
 
-    let http_client = reqwest::ClientBuilder::new()
-        .connect_timeout(Duration::from_secs(15))
-        .timeout(Duration::from_secs(30))
-        .build()
-        .into_diagnostic()?;
-
-    Ok(artifact_keeper_sdk::Client::new_with_client(
-        &instance.url,
-        http_client,
-    ))
+    anon_client(&instance.url)
 }
 
 #[cfg(test)]
@@ -169,5 +192,78 @@ mod tests {
             let client = build_client("test", &instance, Some(&cred));
             assert!(client.is_ok(), "Failed to build client for URL: {url}");
         }
+    }
+
+    // ---- custom CA (--ca-cert / AK_CA_CERT) ----
+
+    use crate::test_utils::ENV_LOCK;
+    use crate::transport::test_ca::{TEST_CA_PEM_1, TEST_CA_PEM_2};
+
+    fn https_instance() -> InstanceConfig {
+        InstanceConfig {
+            url: "https://registry.internal.corp:8443".to_string(),
+            api_version: "v1".to_string(),
+            allow_insecure_http: false,
+        }
+    }
+
+    fn cred() -> StoredCredential {
+        StoredCredential {
+            access_token: "token".to_string(),
+            refresh_token: None,
+        }
+    }
+
+    #[test]
+    fn build_client_with_custom_ca_bundle() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bundle.pem");
+        std::fs::write(&path, format!("{TEST_CA_PEM_1}{TEST_CA_PEM_2}")).unwrap();
+        unsafe { std::env::set_var(transport::CA_CERT_ENV, &path) };
+
+        let client = build_client("test", &https_instance(), Some(&cred()));
+        assert!(client.is_ok(), "{:?}", client.err());
+        assert!(anon_client("https://registry.internal.corp:8443").is_ok());
+        assert!(raw_http_client().is_ok());
+
+        unsafe { std::env::remove_var(transport::CA_CERT_ENV) };
+    }
+
+    #[test]
+    fn build_client_with_invalid_ca_is_clear_error() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("bad.pem");
+        std::fs::write(&path, "not a certificate").unwrap();
+        unsafe { std::env::set_var(transport::CA_CERT_ENV, &path) };
+
+        for msg in [
+            build_client("test", &https_instance(), Some(&cred()))
+                .err()
+                .map(|e| e.to_string()),
+            anon_client("https://registry.internal.corp:8443")
+                .err()
+                .map(|e| e.to_string()),
+            raw_http_client().err().map(|e| e.to_string()),
+        ] {
+            let msg = msg.expect("client build must fail with an invalid CA file");
+            assert!(msg.contains("CA certificate error"), "{msg}");
+        }
+
+        unsafe { std::env::remove_var(transport::CA_CERT_ENV) };
+    }
+
+    #[test]
+    fn build_client_with_missing_ca_file_is_clear_error() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var(transport::CA_CERT_ENV, "/nonexistent/ca.pem") };
+
+        let err = build_client("test", &https_instance(), Some(&cred()))
+            .map(|_| ())
+            .expect_err("client build must fail with a missing CA file");
+        assert!(err.to_string().contains("cannot read"), "{err}");
+
+        unsafe { std::env::remove_var(transport::CA_CERT_ENV) };
     }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -126,11 +126,14 @@ fn pluralize<'a>(count: u32, singular: &'a str, plural: &'a str) -> &'a str {
 
 fn build_diag_client(
     instance: &InstanceConfig,
-) -> std::result::Result<artifact_keeper_sdk::Client, reqwest::Error> {
-    let http_client = reqwest::ClientBuilder::new()
+) -> std::result::Result<artifact_keeper_sdk::Client, String> {
+    let builder = reqwest::ClientBuilder::new()
         .connect_timeout(DIAG_CONNECT_TIMEOUT)
-        .timeout(DIAG_REQUEST_TIMEOUT)
-        .build()?;
+        .timeout(DIAG_REQUEST_TIMEOUT);
+    let http_client = crate::transport::apply_custom_ca(builder)
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?;
 
     Ok(artifact_keeper_sdk::Client::new_with_client(
         &instance.url,
@@ -149,10 +152,12 @@ fn build_diag_client_with_auth(
         HeaderValue::from_str(&auth_value).map_err(|e| e.to_string())?,
     );
 
-    let http_client = reqwest::ClientBuilder::new()
+    let builder = reqwest::ClientBuilder::new()
         .default_headers(headers)
         .connect_timeout(DIAG_CONNECT_TIMEOUT)
-        .timeout(DIAG_REQUEST_TIMEOUT)
+        .timeout(DIAG_REQUEST_TIMEOUT);
+    let http_client = crate::transport::apply_custom_ca(builder)
+        .map_err(|e| e.to_string())?
         .build()
         .map_err(|e| e.to_string())?;
 

--- a/src/commands/email_subscriptions.rs
+++ b/src/commands/email_subscriptions.rs
@@ -158,7 +158,7 @@ async fn subscribe(
     let (base_url, auth_header) = resolve_base_url_and_auth(global)?;
     let spinner = output::spinner("Creating email subscription...");
 
-    let http = reqwest::Client::new();
+    let http = super::client::raw_http_client()?;
     let resp = http
         .post(format!(
             "{}/api/v1/repositories/{repo}/email-subscriptions",

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -847,7 +847,7 @@ async fn job_stream(id: &str, global: &GlobalArgs) -> Result<()> {
         job_id
     );
 
-    let http = reqwest::Client::new();
+    let http = super::client::raw_http_client()?;
     let resp = http
         .get(&url)
         .header(reqwest::header::AUTHORIZATION, auth_header)

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -387,7 +387,7 @@ async fn create_policy(
     let (base_url, auth_header) = resolve_base_url_and_auth(global)?;
     let spinner = output::spinner("Creating lifecycle policy...");
 
-    let http = reqwest::Client::new();
+    let http = super::client::raw_http_client()?;
     let resp = http
         .post(format!(
             "{}/api/v1/admin/lifecycle",
@@ -497,7 +497,7 @@ async fn update_policy(
     let (base_url, auth_header) = resolve_base_url_and_auth(global)?;
     let spinner = output::spinner("Updating lifecycle policy...");
 
-    let http = reqwest::Client::new();
+    let http = super::client::raw_http_client()?;
     let resp = http
         .patch(format!(
             "{}/api/v1/admin/lifecycle/{id}",

--- a/src/commands/service_account.rs
+++ b/src/commands/service_account.rs
@@ -334,7 +334,7 @@ async fn create_account(name: &str, description: Option<&str>, global: &GlobalAr
     // `200 OK` here, but the generated client (`create_service_account`) only
     // accepts `201`, so every successful create was reported as an error even
     // though the account was created (#98). Accept any 2xx success status.
-    let result = reqwest::Client::new()
+    let result = super::client::raw_http_client()?
         .post(format!("{base_url}/api/v1/service-accounts"))
         .header(reqwest::header::AUTHORIZATION, &auth_header)
         .json(&body)

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -315,15 +315,7 @@ impl App {
             Some(ref c) => build_client(instance_name, &instance, Some(c)).ok(),
             None => {
                 // Fall back to unauthenticated client
-                let http_client = reqwest::ClientBuilder::new()
-                    .connect_timeout(std::time::Duration::from_secs(15))
-                    .timeout(std::time::Duration::from_secs(30))
-                    .build()
-                    .ok()?;
-                Some(artifact_keeper_sdk::Client::new_with_client(
-                    &instance.url,
-                    http_client,
-                ))
+                super::client::anon_client(&instance.url).ok()
             }
         }
     }
@@ -336,13 +328,12 @@ impl App {
                 None => continue,
             };
 
-            let http_client = match reqwest::ClientBuilder::new()
+            let builder = reqwest::ClientBuilder::new()
                 .connect_timeout(std::time::Duration::from_secs(3))
-                .timeout(std::time::Duration::from_secs(5))
-                .build()
-            {
-                Ok(c) => c,
-                Err(_) => {
+                .timeout(std::time::Duration::from_secs(5));
+            let http_client = match crate::transport::apply_custom_ca(builder).map(|b| b.build()) {
+                Ok(Ok(c)) => c,
+                _ => {
                     self.instances[i].status = "error".to_string();
                     continue;
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,16 @@ pub enum AkError {
     #[diagnostic(code(ak::config_error))]
     ConfigError(String),
 
+    #[error("CA certificate error: {0}")]
+    #[diagnostic(
+        code(ak::ca_cert),
+        help(
+            "Provide a readable PEM-encoded certificate file (one or more \
+             '-----BEGIN CERTIFICATE-----' blocks) via --ca-cert <path> or AK_CA_CERT."
+        )
+    )]
+    CaCert(String),
+
     #[error("Refusing to send a password over unencrypted HTTP to '{0}'")]
     #[diagnostic(
         code(ak::insecure_transport),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -7,11 +7,93 @@
 //! opts in. Loopback hosts (localhost / 127.0.0.0/8 / ::1) are exempt because
 //! plain HTTP is the normal local development setup.
 
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
 use crate::config::InstanceConfig;
+use crate::error::AkError;
 
 /// Environment variable that globally opts in to sending credentials over
 /// plaintext HTTP to non-loopback hosts.
 pub const ALLOW_INSECURE_HTTP_ENV: &str = "AK_ALLOW_INSECURE_HTTP";
+
+/// Environment variable pointing at a PEM file with additional root CA
+/// certificate(s) to trust (equivalent to the global `--ca-cert` flag).
+pub const CA_CERT_ENV: &str = "AK_CA_CERT";
+
+/// Process-wide value of the `--ca-cert` flag, recorded once at startup.
+///
+/// Clients are constructed in many places (SDK wrappers, raw chunked-upload
+/// HTTP, doctor, TUI), several of which have no access to parsed CLI args, so
+/// the flag is stashed here — mirroring how `AK_ALLOW_INSECURE_HTTP` is read
+/// process-globally.
+static CA_CERT_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+
+/// Record the `--ca-cert` flag value. Called once from `Cli::execute`;
+/// subsequent calls are ignored.
+pub fn set_ca_cert_override(path: PathBuf) {
+    let _ = CA_CERT_OVERRIDE.set(path);
+}
+
+/// Resolve the effective custom CA bundle path: the `--ca-cert` flag if given,
+/// otherwise the `AK_CA_CERT` environment variable, otherwise none.
+pub fn ca_cert_path() -> Option<PathBuf> {
+    if let Some(path) = CA_CERT_OVERRIDE.get() {
+        return Some(path.clone());
+    }
+    std::env::var_os(CA_CERT_ENV)
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Load one or more PEM-encoded certificates from a file.
+///
+/// Accepts a single certificate or a bundle (multiple concatenated
+/// `-----BEGIN CERTIFICATE-----` blocks). Fails with a descriptive error if
+/// the file is missing, unreadable, or contains no valid certificate.
+pub fn load_ca_certificates(path: &Path) -> Result<Vec<reqwest::Certificate>, AkError> {
+    let pem = std::fs::read(path).map_err(|e| {
+        AkError::CaCert(format!(
+            "cannot read CA certificate file '{}': {e}",
+            path.display()
+        ))
+    })?;
+
+    let certs = reqwest::Certificate::from_pem_bundle(&pem).map_err(|e| {
+        AkError::CaCert(format!(
+            "'{}' is not a valid PEM certificate file: {e}",
+            path.display()
+        ))
+    })?;
+
+    if certs.is_empty() {
+        return Err(AkError::CaCert(format!(
+            "no certificates found in '{}' (expected at least one \
+             '-----BEGIN CERTIFICATE-----' block)",
+            path.display()
+        )));
+    }
+
+    Ok(certs)
+}
+
+/// Add the configured custom CA certificate(s) (`--ca-cert` / `AK_CA_CERT`),
+/// if any, to a reqwest client builder.
+///
+/// The custom roots are ADDED to the default trust store — certificate
+/// verification stays fully enabled. This is the supported way to talk to an
+/// instance behind a private/enterprise CA; there is deliberately no
+/// "disable verification" escape hatch.
+pub fn apply_custom_ca(
+    mut builder: reqwest::ClientBuilder,
+) -> Result<reqwest::ClientBuilder, AkError> {
+    if let Some(path) = ca_cert_path() {
+        for cert in load_ca_certificates(&path)? {
+            builder = builder.add_root_certificate(cert);
+        }
+    }
+    Ok(builder)
+}
 
 /// How safe it is to send credentials to a given instance URL.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,6 +180,38 @@ pub fn warn_if_insecure(instance_name: &str, instance: &InstanceConfig) -> bool 
     } else {
         false
     }
+}
+
+/// Self-signed throwaway CA certificates shared by transport and client tests.
+#[cfg(test)]
+pub(crate) mod test_ca {
+    /// Self-signed test CA (CN=AK Test CA 1), P-256, generated for these tests.
+    pub const TEST_CA_PEM_1: &str = "-----BEGIN CERTIFICATE-----
+MIIBhDCCASmgAwIBAgIUc9CR+p5OHSH4QMsCfuxAyJK5Wd0wCgYIKoZIzj0EAwIw
+FzEVMBMGA1UEAwwMQUsgVGVzdCBDQSAxMB4XDTI2MDcwOTIxMjE1NVoXDTI2MDgw
+ODIxMjE1NVowFzEVMBMGA1UEAwwMQUsgVGVzdCBDQSAxMFkwEwYHKoZIzj0CAQYI
+KoZIzj0DAQcDQgAET46Pidr+fHLEc9Q7FEd+dqkKgDU/+i1JAJbZudtGjEE87tuG
+SKckU/P6f1eTRjhktFlD2OuyM7h8YqM2FPR6oKNTMFEwHQYDVR0OBBYEFPjfTLd9
+p1qbNhEqnIlv9sCo9XShMB8GA1UdIwQYMBaAFPjfTLd9p1qbNhEqnIlv9sCo9XSh
+MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhALiCGONXjb1HDfi7
+opgJ26ReB2DqbmfeZZNfrbMhrZqJAiEAqJJu5nsnp4v/i+i2lTYhy8RnFlDWO9Zu
+ze/9pEYSScE=
+-----END CERTIFICATE-----
+";
+
+    /// A second, distinct self-signed test CA (CN=AK Test CA 2).
+    pub const TEST_CA_PEM_2: &str = "-----BEGIN CERTIFICATE-----
+MIIBgzCCASmgAwIBAgIUZsU+wackrRfZYXZIP0rfk+SUmBMwCgYIKoZIzj0EAwIw
+FzEVMBMGA1UEAwwMQUsgVGVzdCBDQSAyMB4XDTI2MDcwOTIxMjE1NVoXDTI2MDgw
+ODIxMjE1NVowFzEVMBMGA1UEAwwMQUsgVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYI
+KoZIzj0DAQcDQgAEUFwH5yhlBaPfCWMwpHDTw+O8MYRZDSzQqGnRRr88zSrSRZ+j
+e4csqx797H4bQscJ4D99XQY+gXizqaceHVcfPKNTMFEwHQYDVR0OBBYEFK7XgrHC
+QbeZ3/O175I1NmBMKjSGMB8GA1UdIwQYMBaAFK7XgrHCQbeZ3/O175I1NmBMKjSG
+MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAJz+Yz/eMcRzyJ9J
+WWp+uGnGQgcpALGLLUOCgLAIii+qAiB2T2Uc8Tsk/uosedAywcwiZ06+S615+MNb
+RrZxwmFE/Q==
+-----END CERTIFICATE-----
+";
 }
 
 #[cfg(test)]
@@ -249,5 +363,108 @@ mod tests {
             "t",
             &instance("https://registry.example.com", false)
         ));
+    }
+
+    // ---- custom CA certificates ----
+
+    use test_ca::{TEST_CA_PEM_1, TEST_CA_PEM_2};
+
+    fn write_temp(contents: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("ca.pem");
+        std::fs::write(&path, contents).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn load_single_ca_certificate() {
+        let (_dir, path) = write_temp(TEST_CA_PEM_1);
+        let certs = load_ca_certificates(&path).unwrap();
+        assert_eq!(certs.len(), 1);
+    }
+
+    #[test]
+    fn load_ca_bundle_with_multiple_certs() {
+        let bundle = format!("{TEST_CA_PEM_1}{TEST_CA_PEM_2}");
+        let (_dir, path) = write_temp(&bundle);
+        let certs = load_ca_certificates(&path).unwrap();
+        assert_eq!(certs.len(), 2);
+    }
+
+    #[test]
+    fn load_missing_file_is_clear_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("does-not-exist.pem");
+        let err = load_ca_certificates(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("cannot read CA certificate file"), "{msg}");
+        assert!(msg.contains("does-not-exist.pem"), "{msg}");
+    }
+
+    #[test]
+    fn load_invalid_pem_is_clear_error() {
+        let (_dir, path) = write_temp("this is not a certificate");
+        let err = load_ca_certificates(&path).unwrap_err();
+        let msg = err.to_string();
+        // Depending on how the parser treats garbage, this surfaces as either
+        // an invalid-PEM error or an empty bundle — both must be clear errors.
+        assert!(
+            msg.contains("not a valid PEM certificate file") || msg.contains("no certificates"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn load_empty_file_is_clear_error() {
+        let (_dir, path) = write_temp("");
+        let err = load_ca_certificates(&path).unwrap_err();
+        assert!(err.to_string().contains("no certificates"), "{}", err);
+    }
+
+    #[test]
+    fn ca_cert_path_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var(CA_CERT_ENV, "/some/ca.pem") };
+        assert_eq!(
+            ca_cert_path(),
+            Some(std::path::PathBuf::from("/some/ca.pem"))
+        );
+        unsafe { std::env::set_var(CA_CERT_ENV, "") };
+        assert_eq!(ca_cert_path(), None);
+        unsafe { std::env::remove_var(CA_CERT_ENV) };
+        assert_eq!(ca_cert_path(), None);
+    }
+
+    #[test]
+    fn apply_custom_ca_builds_client() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let bundle = format!("{TEST_CA_PEM_1}{TEST_CA_PEM_2}");
+        let (_dir, path) = write_temp(&bundle);
+        unsafe { std::env::set_var(CA_CERT_ENV, &path) };
+
+        let builder = apply_custom_ca(reqwest::ClientBuilder::new()).unwrap();
+        assert!(builder.build().is_ok());
+
+        unsafe { std::env::remove_var(CA_CERT_ENV) };
+    }
+
+    #[test]
+    fn apply_custom_ca_propagates_load_errors() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_dir, path) = write_temp("garbage");
+        unsafe { std::env::set_var(CA_CERT_ENV, &path) };
+
+        let err = apply_custom_ca(reqwest::ClientBuilder::new()).unwrap_err();
+        assert!(matches!(err, AkError::CaCert(_)));
+
+        unsafe { std::env::remove_var(CA_CERT_ENV) };
+    }
+
+    #[test]
+    fn apply_custom_ca_noop_without_config() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::remove_var(CA_CERT_ENV) };
+        let builder = apply_custom_ca(reqwest::ClientBuilder::new()).unwrap();
+        assert!(builder.build().is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Adds custom CA certificate support for enterprise/private-CA TLS environments (Closes #76).

- New global `--ca-cert <PATH>` flag and `AK_CA_CERT` environment variable pointing at a PEM file with one or more root CA certificates (bundles supported via `reqwest::Certificate::from_pem_bundle`).
- The certificate(s) are **added** to the default trust store with `add_root_certificate`; TLS verification always remains enabled. No insecure/skip-verification option is introduced — this is the supported counterpart to the plaintext-HTTP guardrails in `src/transport.rs`.
- Wired into every HTTP client construction site so the whole CLI honors it:
  - `build_client` / `client_for_optional_auth` (SDK wrappers)
  - new `anon_client` helper for pre-auth flows (`auth login`, TOTP verify, setup status) — critical since login is the first thing a user does against a private-CA instance
  - new `raw_http_client` helper replacing bare `reqwest::Client::new()` in the raw HTTP paths (chunked upload/resume, SSE progress streams, multipart import + plugin ZIP install, service-account create, lifecycle create/update, email subscriptions)
  - `doctor` diagnostic clients and TUI clients
- Clear diagnostics instead of panics or opaque TLS failures: missing/unreadable file, invalid PEM, and empty bundle all fail with a dedicated `ak::ca_cert` error including help text.
- Docs: README section + environment-variable table entry; CLAUDE.md env table.

## Test Checklist

- [x] `cargo build` / `cargo build --release` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings -A dead_code` clean
- [x] `cargo test --workspace`: 2095 passed, 0 failed
- [x] New unit tests: flag/env parsing (`--ca-cert` global position, env fallback, flag-over-env precedence, missing value rejected), PEM load success, multi-cert bundle, missing file, invalid PEM, empty file, client-build success/error paths for `build_client`/`anon_client`/`raw_http_client`
- [x] Functional check against a live backend: fronted a v1.4.0 instance with a TLS terminator using a server certificate issued by a locally generated private CA:
  - without `--ca-cert`: request fails TLS verification (unknown issuer)
  - with `--ca-cert <ca.pem>`: full `ak repo list` round-trip succeeds over HTTPS
  - with `AK_CA_CERT` env: same success
  - with a PEM bundle containing two CAs (correct one second): success
  - with the **wrong** CA: still fails — proves verification stays on and the flag only adds trust
  - plain-HTTP instance with and without `--ca-cert`: behavior unchanged
- [x] Cross-platform: no unix-only code; reqwest certificate APIs are portable (Windows build job covers it)

## API Changes

None (client-side only). New CLI surface: global `--ca-cert` flag, `AK_CA_CERT` env var, `ak::ca_cert` diagnostic code.
