### PR TITLE
refactor(sdk): replace glob re-export with explicit public API facade

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,3 +1,12 @@
+//! Rust SDK for the Artifact Keeper REST API.
+//!
+//! The items re-exported below form the crate's intentional public API.
+//! The `generated_sdk` module is produced by `cargo xtask generate` and is
+//! deliberately private: only the names listed here are exposed, so an SDK
+//! regeneration cannot silently change the public surface. When regeneration
+//! adds a new operation tag (a new `Client*Ext` trait) or top-level item,
+//! add it to the explicit re-export list below.
+
 /// Re-export progenitor_client for consumers.
 pub use progenitor_client;
 pub use reqwest;
@@ -5,4 +14,22 @@ pub use reqwest;
 #[allow(clippy::all, unused, dead_code, unreachable_code)]
 mod generated_sdk;
 
-pub use generated_sdk::*;
+// Core client and progenitor runtime types used in operation signatures.
+pub use generated_sdk::{ByteStream, Client, ClientInfo, Error, ResponseValue};
+
+// Namespaced modules: request/response types, operation builders, and the
+// convenience prelude (Client + all extension traits).
+pub use generated_sdk::{builder, prelude, types};
+
+// Per-tag operation extension traits.
+pub use generated_sdk::{
+    ClientAdminExt, ClientAgeGateExt, ClientAnalyticsExt, ClientApprovalExt,
+    ClientArtifactLabelsExt, ClientArtifactsExt, ClientAuthExt, ClientBuildsExt, ClientCurationExt,
+    ClientEmailSubscriptionsExt, ClientGroupsExt, ClientHealthExt, ClientLifecycleExt,
+    ClientMigrationExt, ClientMonitoringExt, ClientPackagesExt, ClientPeerInstanceLabelsExt,
+    ClientPeersExt, ClientPermissionsExt, ClientPluginsExt, ClientPromotionExt, ClientQualityExt,
+    ClientQuarantineExt, ClientRepositoriesExt, ClientRepositoryLabelsExt,
+    ClientRepositoryTokensExt, ClientSbomExt, ClientSearchExt, ClientSecurityExt,
+    ClientServiceAccountsExt, ClientSigningExt, ClientSsoExt, ClientSystemExt, ClientTelemetryExt,
+    ClientUploadsExt, ClientUsersExt, ClientWebhooksExt,
+};


### PR DESCRIPTION
## Summary

`sdk/src/lib.rs` previously did `pub use generated_sdk::*`, which made every item in the 100k-line generated module part of the crate's public API. Any `cargo xtask generate` run could silently add, remove, or change public items, and consumers could accidentally depend on transitively-exposed internals.

This replaces the glob with an explicit facade. The `generated_sdk` module stays private; only the listed names are exposed.

## Approach

Full explicit enumeration was practical here because the generated module's top level is small (~45 names) even though the file is huge — the hundreds of request/response types already live under the `types` module and the operation builders under `builder`, so those stay namespaced rather than being flattened.

Explicitly re-exported:

- **Core**: `Client`, plus the progenitor runtime types used in operation signatures: `ByteStream`, `ClientInfo`, `Error`, `ResponseValue`
- **Namespaced modules**: `types` (request/response schemas), `builder` (operation builders), `prelude` (Client + all extension traits)
- **All 37 `Client*Ext` per-tag operation traits**, listed by name

The existing `pub use progenitor_client;` / `pub use reqwest;` re-exports are unchanged. A doc comment notes that regeneration which adds a new operation tag now requires an intentional edit to the facade list — which is the point of the change.

## Verification

- `cargo build --workspace` — clean (the CLI binary is the real consumer test; nothing it imports was dropped)
- `cargo build --release` — clean
- `cargo fmt --check` — clean
- `cargo clippy --workspace -- -D warnings -A dead_code` — clean
- `cargo test --workspace` — 2095 passed, 0 failed (e2e tests ignored as usual, backend-gated)

No behavior change; pure re-export restructuring, so Windows compatibility is unaffected. Scope is confined to `sdk/src/lib.rs` and does not touch the lint configuration (kept clear of the #70 work).

Closes #72